### PR TITLE
chore: consume published @symbiote-native/test-utils from npm in examples

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -37,7 +37,7 @@
     "@react-native/metro-config": "catalog:",
     "@react-native/typescript-config": "catalog:",
     "@symbiote-native/css-parser": "catalog:",
-    "@symbiote-native/test-utils": "workspace:*",
+    "@symbiote-native/test-utils": "catalog:",
     "@types/jest": "catalog:",
     "@types/react": "catalog:",
     "detox": "catalog:",

--- a/examples/vue-tsx/package.json
+++ b/examples/vue-tsx/package.json
@@ -35,7 +35,7 @@
     "@react-native/metro-config": "catalog:",
     "@react-native/typescript-config": "catalog:",
     "@symbiote-native/css-parser": "catalog:",
-    "@symbiote-native/test-utils": "workspace:*",
+    "@symbiote-native/test-utils": "catalog:",
     "@types/jest": "catalog:",
     "@vue/babel-plugin-jsx": "catalog:",
     "detox": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     '@symbiote-native/slider':
       specifier: ^0.1.1
       version: 0.1.1
+    '@symbiote-native/test-utils':
+      specifier: ^0.1.1
+      version: 0.1.1
     '@symbiote-native/vue':
       specifier: ^0.1.1
       version: 0.1.1
@@ -554,8 +557,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.1(typescript@6.0.3)
       '@symbiote-native/test-utils':
-        specifier: workspace:*
-        version: link:../../core/test-utils
+        specifier: 'catalog:'
+        version: 0.1.1
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -742,8 +745,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.1(typescript@6.0.3)
       '@symbiote-native/test-utils':
-        specifier: workspace:*
-        version: link:../../core/test-utils
+        specifier: 'catalog:'
+        version: 0.1.1
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -2855,6 +2858,9 @@ packages:
         optional: true
       vue:
         optional: true
+
+  '@symbiote-native/test-utils@0.1.1':
+    resolution: {integrity: sha512-pzreAWXEmT/d7QDQ1RlyIoiHmA6GDJxitsj2Qiih/l7OOTDn3wx1Y1OcuJC68gHQOAJ9H9On+oqUlJeVT+aIhA==}
 
   '@symbiote-native/vue@0.1.1':
     resolution: {integrity: sha512-hMhmEgh052nXkMrjyN9Q1WJHFoLa89MnXjxBuS6yLQppayvhiTgR07PJwbM9azmjWZ4wIr0mS07CAwu2jjlfQg==}
@@ -10153,6 +10159,8 @@ snapshots:
       '@vue/runtime-core': 3.5.38
       react: 19.2.3
       vue: 3.5.38(typescript@6.0.3)
+
+  '@symbiote-native/test-utils@0.1.1': {}
 
   '@symbiote-native/vue@0.1.1(react-native@0.86.0(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@6.0.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ minimumReleaseAgeExclude:
   - '@symbiote-native/react@0.1.1'
   - '@symbiote-native/slider@0.1.1'
   - '@symbiote-native/vue@0.1.1'
+  - '@symbiote-native/test-utils@0.1.1'
 
 # Single source of truth for dependency versions (pnpm catalogs).
 # A package references a version with `catalog:` (default) or `catalog:<name>`
@@ -90,7 +91,7 @@ catalog:
   '@symbiote-native/components': ^0.1.1
   '@symbiote-native/css-parser': ^0.1.1
   '@symbiote-native/slider': ^0.1.1
-  '@symbiote-native/test-utils': ^0.1.0
+  '@symbiote-native/test-utils': ^0.1.1
 
   # React Native app toolchain — single-versioned, used only by examples/*
   '@react-native/babel-preset': 0.86.0


### PR DESCRIPTION
## Summary
- `@symbiote-native/test-utils@0.1.1` is now live on npm (published manually, first release of a new scoped package).
- Switch `examples/react` and `examples/vue-tsx` off `workspace:*` onto `catalog:` for it, matching the other already-published `@symbiote-native/*` deps.
- Bump the `pnpm-workspace.yaml` catalog entry to `^0.1.1` to match.

## Test plan
- [x] `pnpm install` resolves `@symbiote-native/test-utils` from the real npm registry (`node_modules/.pnpm/@symbiote-native+test-utils@0.1.1/...`), not a workspace symlink
- [x] `npx tsc --build` passes
- [x] `syncpack lint` passes