### PR TITLE
feat: add zero-config bootstrap for react, vue, and angular adapters

### DIFF
--- a/.changeset/bootstrap-host.md
+++ b/.changeset/bootstrap-host.md
@@ -1,0 +1,8 @@
+---
+"@symbiote-native/components": minor
+"@symbiote-native/react": minor
+"@symbiote-native/vue": minor
+"@symbiote-native/angular": minor
+---
+
+Add a zero-config host bootstrap (`bootstrapHost` in `@symbiote-native/components`, plus `registerApp` / `createApp` / `bootstrapApplication` per adapter) that wires the native-host seams and AppRegistry in one call, collapsing the manual per-app wiring every canary previously repeated.

--- a/adapters/angular/package.json
+++ b/adapters/angular/package.json
@@ -22,6 +22,11 @@
       "react-native": "./build/angular/index.js",
       "default": "./src/index.ts"
     },
+    "./bootstrap": {
+      "types": "./build/angular/bootstrap.d.ts",
+      "react-native": "./build/angular/bootstrap.js",
+      "default": "./src/bootstrap.ts"
+    },
     "./metro-css-parser": "./metro-css-parser.cjs"
   },
   "files": [

--- a/adapters/angular/src/bootstrap.ts
+++ b/adapters/angular/src/bootstrap.ts
@@ -1,0 +1,26 @@
+// Zero-config app entry, the Angular twin of adapters/react/src/bootstrap.ts. Lives OUTSIDE the
+// package's main barrel — see that file's header for why anything importing react-native must
+// stay there. No @Component/@Directive decorators here, so unlike the package's main "." entry
+// this needs no ngc/AOT build step and can stay a plain source reference.
+
+import { AppRegistry as RNAppRegistry } from 'react-native';
+import type { Type } from '@angular/core';
+import { bootstrapHost, type IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+import { AppRegistry, setHostRegistrar } from './modules/app-registry';
+
+export type { IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+
+export type IBootstrapApplicationOptions = IBootstrapHostOptions & {
+  appName: string;
+};
+
+// Mirrors real Angular's bootstrapApplication(RootComponent, config) idiom.
+export function bootstrapApplication(
+  AppComponent: Type<unknown>,
+  options: IBootstrapApplicationOptions,
+): void {
+  const { appName, ...bootstrapOptions } = options;
+  bootstrapHost(bootstrapOptions);
+  setHostRegistrar(RNAppRegistry);
+  AppRegistry.registerComponent(appName, () => AppComponent);
+}

--- a/adapters/react/package.json
+++ b/adapters/react/package.json
@@ -18,6 +18,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./bootstrap": "./src/bootstrap.ts",
     "./metro-css-parser": "./metro-css-parser.cjs"
   },
   "files": [
@@ -33,6 +34,10 @@
       ".": {
         "types": "./build/index.d.ts",
         "default": "./build/index.js"
+      },
+      "./bootstrap": {
+        "types": "./build/bootstrap.d.ts",
+        "default": "./build/bootstrap.js"
       },
       "./metro-css-parser": "./metro-css-parser.cjs"
     }

--- a/adapters/react/src/bootstrap.ts
+++ b/adapters/react/src/bootstrap.ts
@@ -1,0 +1,26 @@
+// Zero-config app entry: wires the four RN-backed host seams (via @symbiote-native/components'
+// bootstrapHost) plus this adapter's own AppRegistry host-registrar bridge, then registers the
+// root component — collapsing the canary's manual sequence into one call. Lives OUTSIDE the
+// package's main barrel (see package.json's "./bootstrap" export): it imports react-native
+// directly, which Vitest's Flow-unaware transform can't parse (see
+// @symbiote-native/components/bootstrap for the full reason).
+
+import type { ComponentType } from 'react';
+import { AppRegistry as RNAppRegistry } from 'react-native';
+import { bootstrapHost, type IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+import { AppRegistry, setHostRegistrar } from './modules/app-registry';
+
+export type { IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+
+export type IRegisterAppOptions = IBootstrapHostOptions & {
+  appName: string;
+};
+
+// Mirrors bare RN's own `AppRegistry.registerComponent(appName, () => App)` idiom, minus the
+// manual host wiring in front of it.
+export function registerApp(App: ComponentType<object>, options: IRegisterAppOptions): void {
+  const { appName, ...bootstrapOptions } = options;
+  bootstrapHost(bootstrapOptions);
+  setHostRegistrar(RNAppRegistry);
+  AppRegistry.registerComponent(appName, () => App);
+}

--- a/adapters/vue/package.json
+++ b/adapters/vue/package.json
@@ -18,6 +18,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./bootstrap": "./src/bootstrap.ts",
     "./runtime-helpers": "./src/runtime-helpers.ts",
     "./metro-css-parser": "./metro-css-parser.cjs"
   },
@@ -34,6 +35,10 @@
       ".": {
         "types": "./build/index.d.ts",
         "default": "./build/index.js"
+      },
+      "./bootstrap": {
+        "types": "./build/bootstrap.d.ts",
+        "default": "./build/bootstrap.js"
       },
       "./runtime-helpers": {
         "types": "./build/runtime-helpers.d.ts",

--- a/adapters/vue/src/bootstrap.ts
+++ b/adapters/vue/src/bootstrap.ts
@@ -1,0 +1,26 @@
+// Zero-config app entry, the Vue twin of adapters/react/src/bootstrap.ts. createApp(App) stays
+// inert (matching real Vue's own semantics); mount(appName) is where the RN host seams and
+// AppRegistry actually get wired. Lives OUTSIDE the package's main barrel — see that file's
+// header for why anything importing react-native must stay there.
+
+import { AppRegistry as RNAppRegistry } from 'react-native';
+import type { Component } from '@vue/runtime-core';
+import { bootstrapHost, type IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+import { AppRegistry, setHostRegistrar } from './modules/app-registry';
+
+export type { IBootstrapHostOptions } from '@symbiote-native/components/bootstrap';
+
+export type ISymbioteVueApp = {
+  mount(appName: string): void;
+};
+
+// Mirrors real Vue's createApp(App).mount(selector) two-step idiom.
+export function createApp(App: Component, options: IBootstrapHostOptions = {}): ISymbioteVueApp {
+  return {
+    mount(appName: string): void {
+      bootstrapHost(options);
+      setHostRegistrar(RNAppRegistry);
+      AppRegistry.registerComponent(appName, () => App);
+    },
+  };
+}

--- a/core/components/package.json
+++ b/core/components/package.json
@@ -17,7 +17,8 @@
   "module": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./bootstrap": "./src/bootstrap.ts"
   },
   "files": [
     "build"
@@ -31,6 +32,10 @@
       ".": {
         "types": "./build/index.d.ts",
         "default": "./build/index.js"
+      },
+      "./bootstrap": {
+        "types": "./build/bootstrap.d.ts",
+        "default": "./build/bootstrap.js"
       }
     }
   },
@@ -40,5 +45,11 @@
   },
   "dependencies": {
     "@symbiote-native/engine": "workspace:*"
+  },
+  "peerDependencies": {
+    "react-native": ">=0.86"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:"
   }
 }

--- a/core/components/src/bootstrap.test.ts
+++ b/core/components/src/bootstrap.test.ts
@@ -1,0 +1,60 @@
+// Unit test for the zero-config host bootstrap (see bootstrap.ts's header for why this file
+// stays outside @symbiote-native/components' main barrel). react-native itself is mocked: its
+// real source is Flow syntax Vitest's Rolldown-based transform cannot parse.
+import { describe, expect, it, vi } from 'vitest';
+
+const setColorProcessor = vi.fn();
+const setDeviceEventSource = vi.fn();
+const setNativeViewConfigSource = vi.fn();
+const setImageSourceResolver = vi.fn();
+
+vi.mock('react-native', () => ({
+  processColor: vi.fn(),
+  DeviceEventEmitter: { addListener: vi.fn() },
+  Image: { resolveAssetSource: vi.fn() },
+}));
+vi.mock('react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry', () => ({
+  get: vi.fn(),
+}));
+vi.mock('@symbiote-native/engine', () => ({
+  setColorProcessor,
+  setDeviceEventSource,
+  setNativeViewConfigSource,
+}));
+vi.mock('./view/render-image', () => ({ setImageSourceResolver }));
+
+const { bootstrapHost } = await import('./bootstrap');
+
+describe('bootstrapHost', () => {
+  it('forwards explicit overrides to every seam instead of touching react-native', () => {
+    const colorProcessor = (): unknown => 'color';
+    const imageSourceResolver = (): unknown => 'image';
+    const deviceEventSource = { addListener: vi.fn() };
+    const nativeViewConfigSource = (): undefined => undefined;
+
+    bootstrapHost({
+      colorProcessor,
+      imageSourceResolver,
+      deviceEventSource,
+      nativeViewConfigSource,
+      debug: true,
+    });
+
+    expect(setColorProcessor).toHaveBeenCalledWith(colorProcessor);
+    expect(setImageSourceResolver).toHaveBeenCalledWith(imageSourceResolver);
+    expect(setDeviceEventSource).toHaveBeenCalledWith(deviceEventSource);
+    expect(setNativeViewConfigSource).toHaveBeenCalledWith(nativeViewConfigSource);
+    expect(globalThis.__SYMBIOTE_DEBUG__).toBe(true);
+  });
+
+  it('defaults debug from process.env.DEBUG when not overridden', () => {
+    bootstrapHost({
+      colorProcessor: () => undefined,
+      imageSourceResolver: () => undefined,
+      deviceEventSource: { addListener: vi.fn() },
+      nativeViewConfigSource: () => undefined,
+    });
+
+    expect(globalThis.__SYMBIOTE_DEBUG__).toBe(process.env.DEBUG === '1');
+  });
+});

--- a/core/components/src/bootstrap.ts
+++ b/core/components/src/bootstrap.ts
@@ -1,0 +1,63 @@
+// Zero-config host bootstrap for @symbiote-native/components' four RN-backed seams
+// (colorProcessor, imageSourceResolver, deviceEventSource, nativeViewConfigSource), wired from
+// real react-native in one call — collapses what every canary example currently hand-wires at
+// startup. Lives OUTSIDE the package's main barrel (see package.json's separate "./bootstrap"
+// export): react-native's own source is Flow syntax Vitest's transform can't parse, so anything
+// importing it directly must stay unreachable from the tested main index.ts.
+
+import { processColor, DeviceEventEmitter, Image, type ImageSourcePropType } from 'react-native';
+import {
+  setColorProcessor,
+  setDeviceEventSource,
+  setNativeViewConfigSource,
+  type IColorValue,
+  type IDeviceEventSource,
+  type INativeViewConfig,
+  type INativeViewConfigSource,
+} from '@symbiote-native/engine';
+import { setImageSourceResolver } from './view/render-image';
+// @ts-expect-error react-native ships no types for this internal path (plain .js) — the
+// try/catch below is what actually proves the shape, not TS.
+import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+
+export type IBootstrapHostOptions = {
+  colorProcessor?: (value: IColorValue) => unknown;
+  imageSourceResolver?: (source: unknown) => unknown;
+  deviceEventSource?: IDeviceEventSource;
+  nativeViewConfigSource?: INativeViewConfigSource;
+  debug?: boolean;
+};
+
+// Third-party Fabric views derive their events + prop processors from RN's own ViewConfig
+// registry; `get` throws for an unregistered name, so undefined is the right answer for
+// anything the registry doesn't know (our built-ins never reach here).
+function defaultNativeViewConfigSource(name: string): INativeViewConfig | undefined {
+  try {
+    return ReactNativeViewConfigRegistry.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+// require('./x.png') asset ids and {uri} sources are resolved by RN's own resolver before they
+// reach the shared render fns. `source` is untyped at the setImageSourceResolver seam by design
+// (any component's resolved shape flows through it) — this is the I/O edge where it crosses
+// into RN's own typed Image API.
+function defaultImageSourceResolver(source: unknown): unknown {
+  return Image.resolveAssetSource(source as ImageSourcePropType);
+}
+
+// IColorValue is our own structural mirror of the runtime shapes RN's processColor accepts
+// (CSS string / PlatformColor / DynamicColorIOS); RN's own ColorValue type is opaque, not
+// structurally identical, so this is the I/O edge between the two color representations.
+function defaultColorProcessor(value: IColorValue): unknown {
+  return processColor(value as Parameters<typeof processColor>[0]);
+}
+
+export function bootstrapHost(options: IBootstrapHostOptions = {}): void {
+  globalThis.__SYMBIOTE_DEBUG__ = options.debug ?? process.env.DEBUG === '1';
+  setColorProcessor(options.colorProcessor ?? defaultColorProcessor);
+  setImageSourceResolver(options.imageSourceResolver ?? defaultImageSourceResolver);
+  setDeviceEventSource(options.deviceEventSource ?? DeviceEventEmitter);
+  setNativeViewConfigSource(options.nativeViewConfigSource ?? defaultNativeViewConfigSource);
+}

--- a/core/components/tsconfig.json
+++ b/core/components/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build"
+    "outDir": "build",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],

--- a/examples/angular/index.js
+++ b/examples/angular/index.js
@@ -1,45 +1,12 @@
 /**
  * @format
  *
- * Symbiote Angular canary entry. Our own AppRegistry (the RN-identical
- * `registerComponent(appKey, () => App)`) mounts via @symbiote-native/engine, not React Native's
- * renderer. setHostRegistrar hands it RN's AppRegistry so the native Fabric host can find our
- * runnable by app key and call it with the surface's rootTag; our renderer drives
- * nativeFabricUIManager directly from there — the same entry point the React canary uses.
+ * Symbiote Angular canary entry. bootstrapApplication wires the native-host seams and RN's own
+ * AppRegistry, then registers the root component — same entry point the other canaries use.
  */
 
-import {
-  AppRegistry as RNAppRegistry,
-  processColor,
-  DeviceEventEmitter,
-} from 'react-native';
-import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-import {
-  AppRegistry,
-  setHostRegistrar,
-  setColorProcessor,
-  setDeviceEventSource,
-  setNativeViewConfigSource,
-} from '@symbiote-native/angular';
+import { bootstrapApplication } from '@symbiote-native/angular/bootstrap';
 import { AppComponent } from './build/angular/App';
 import { name as appName } from './app.json';
 
-globalThis.__SYMBIOTE_DEBUG__ = process.env.DEBUG === '1';
-
-setColorProcessor(processColor);
-setDeviceEventSource(DeviceEventEmitter);
-setNativeViewConfigSource(name => {
-  try {
-    return ReactNativeViewConfigRegistry.get(name);
-  } catch {
-    return undefined;
-  }
-});
-
-// Give our AppRegistry RN's own registrar so the native Fabric host finds our
-// runnable by app key (native drives RN's AppRegistry, not ours).
-setHostRegistrar(RNAppRegistry);
-
-// RN-identical app entry: registerComponent stores a runnable that mounts via
-// @symbiote-native/engine (not React Native's renderer) and bridges it to the host above.
-AppRegistry.registerComponent(appName, () => AppComponent);
+bootstrapApplication(AppComponent, { appName });

--- a/examples/react/index.js
+++ b/examples/react/index.js
@@ -3,59 +3,12 @@
  *
  * Symbiote canary entry. App code uses our own AppRegistry (the RN-identical
  * `registerComponent(appKey, () => App)`) which mounts via @symbiote-native/engine, not
- * React Native's renderer. setHostRegistrar hands it RN's AppRegistry so the
- * native Fabric host can find our runnable by app key and call it with the
- * surface's rootTag; our renderer drives nativeFabricUIManager directly from there.
+ * React Native's renderer; registerApp wires the native-host seams (colors, images, device
+ * events, third-party ViewConfigs) before registering, so this file only needs the app itself.
  */
 
-import {
-  AppRegistry as RNAppRegistry,
-  processColor,
-  Image as RNImage,
-  DeviceEventEmitter,
-} from 'react-native';
-import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-import { AppRegistry, setHostRegistrar, setImageSourceResolver } from '@symbiote-native/react';
-import {
-  setColorProcessor,
-  setDeviceEventSource,
-  setNativeViewConfigSource,
-} from '@symbiote-native/engine';
+import { registerApp } from '@symbiote-native/react/bootstrap';
 import App from './App';
 import { name as appName } from './app.json';
 
-// Diagnostic logs are off unless DEBUG=1 is set when Metro starts (babel inlines
-// it). Mirror it onto the global so shared sees it on any host.
-globalThis.__SYMBIOTE_DEBUG__ = process.env.DEBUG === '1';
-
-// Colors reach Fabric as platform ints; let shared use RN's own converter.
-setColorProcessor(processColor);
-
-// require('./x.png') asset ids and {uri} sources are resolved by RN's own
-// resolver before they reach Fabric, so @symbiote-native/react stays react-native-free.
-setImageSourceResolver(source => RNImage.resolveAssetSource(source));
-
-// Native device events (keyboard, app-state, …) are delivered by RN's own
-// RCTDeviceEventEmitter, the JS module native actually invokes. We subscribe
-// through it rather than registering our own (native ignores a duplicate name).
-setDeviceEventSource(DeviceEventEmitter);
-
-// Third-party Fabric views derive their events + prop processors from RN's own
-// ViewConfig registry (populated by each library's codegen). `get` throws for an
-// unregistered name; our built-ins never reach here, so undefined is the right
-// answer for anything the registry doesn't know.
-setNativeViewConfigSource(name => {
-  try {
-    return ReactNativeViewConfigRegistry.get(name);
-  } catch {
-    return undefined;
-  }
-});
-
-// Give our AppRegistry RN's own registrar so the native Fabric host finds our
-// runnable by app key (native drives RN's AppRegistry, not ours).
-setHostRegistrar(RNAppRegistry);
-
-// RN-identical app entry: registerComponent stores a runnable that mounts via
-// @symbiote-native/engine (not React Native's renderer) and bridges it to the host above.
-AppRegistry.registerComponent(appName, () => App);
+registerApp(App, { appName });

--- a/examples/vue-sfc/index.js
+++ b/examples/vue-sfc/index.js
@@ -1,53 +1,13 @@
 /**
  * @format
  *
- * Symbiote Vue canary entry (M3 / R4 on-device proof). Our own AppRegistry (the RN-identical
- * `registerComponent(appKey, () => App)`) mounts via @symbiote-native/engine, not React Native's
- * renderer. setHostRegistrar hands it RN's AppRegistry so the native Fabric host can find our
- * runnable by app key and call it with the surface's rootTag; our renderer drives
- * nativeFabricUIManager directly from there — the same entry point the React canary uses.
+ * Symbiote Vue canary entry (M3 / R4 on-device proof). createApp(App).mount(appName) wires the
+ * native-host seams and RN's own AppRegistry, then mounts via @symbiote-native/engine — RN's own
+ * renderer is never in the path.
  */
 
-import {
-  AppRegistry as RNAppRegistry,
-  processColor,
-  DeviceEventEmitter,
-} from 'react-native';
-import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-import {
-  setColorProcessor,
-  setDeviceEventSource,
-  setNativeViewConfigSource,
-} from '@symbiote-native/engine';
-import { AppRegistry, setHostRegistrar } from '@symbiote-native/vue';
+import { createApp } from '@symbiote-native/vue/bootstrap';
 import App from './App';
 import { name as appName } from './app.json';
 
-// Diagnostic logs are off unless DEBUG=1 is set when Metro starts (babel inlines it).
-globalThis.__SYMBIOTE_DEBUG__ = process.env.DEBUG === '1';
-
-// Colors reach Fabric as platform ints; let the engine use RN's own converter.
-setColorProcessor(processColor);
-
-// Native device events (keyboard, app-state, …) arrive via RN's own
-// RCTDeviceEventEmitter, the JS module native actually invokes.
-setDeviceEventSource(DeviceEventEmitter);
-
-// Third-party Fabric views derive their events + prop processors from RN's own ViewConfig
-// registry; `get` throws for an unregistered name, so undefined is the right answer for
-// anything the registry doesn't know (our built-ins never reach here).
-setNativeViewConfigSource(name => {
-  try {
-    return ReactNativeViewConfigRegistry.get(name);
-  } catch {
-    return undefined;
-  }
-});
-
-// Give our AppRegistry RN's own registrar so the native Fabric host finds our
-// runnable by app key (native drives RN's AppRegistry, not ours).
-setHostRegistrar(RNAppRegistry);
-
-// RN-identical app entry: registerComponent stores a runnable that mounts via
-// @symbiote-native/engine (not React Native's renderer) and bridges it to the host above.
-AppRegistry.registerComponent(appName, () => App);
+createApp(App).mount(appName);

--- a/examples/vue-tsx/index.js
+++ b/examples/vue-tsx/index.js
@@ -1,53 +1,15 @@
 /**
  * @format
  *
- * Symbiote Vue canary entry (M3 / R4 on-device proof). We register a RUNNABLE with RN's
- * own AppRegistry, not a component, so the native Fabric host invokes it by app key
- * with the surface's rootTag, and we mount the Vue app via @symbiote-native/engine. RN's own
- * renderer is never in the path. (The React canary reaches the same registerRunnable seam
- * through @symbiote-native/react's AppRegistry; the Vue slice has no AppRegistry yet, so we call
- * it directly. It moves into @symbiote-native/components with the rest of the runtime layer.)
+ * Symbiote Vue canary entry (M3 / R4 on-device proof). createApp(App).mount(appName) wires the
+ * native-host seams and RN's own AppRegistry, then mounts via @symbiote-native/engine — RN's own
+ * renderer is never in the path. Same entry point as examples/vue-sfc (this example used to
+ * register a runnable directly; it now goes through the shared AppRegistry seam like every
+ * other canary).
  */
 
-import {
-  AppRegistry as RNAppRegistry,
-  processColor,
-  DeviceEventEmitter,
-} from 'react-native';
-import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-import {
-  setColorProcessor,
-  setDeviceEventSource,
-  setNativeViewConfigSource,
-} from '@symbiote-native/engine';
-import { mount } from '@symbiote-native/vue';
+import { createApp } from '@symbiote-native/vue/bootstrap';
 import App from './App';
 import { name as appName } from './app.json';
 
-// Diagnostic logs are off unless DEBUG=1 is set when Metro starts (babel inlines it).
-globalThis.__SYMBIOTE_DEBUG__ = process.env.DEBUG === '1';
-
-// Colors reach Fabric as platform ints; let the engine use RN's own converter.
-setColorProcessor(processColor);
-
-// Native device events (keyboard, app-state, …) arrive via RN's own
-// RCTDeviceEventEmitter, the JS module native actually invokes.
-setDeviceEventSource(DeviceEventEmitter);
-
-// Third-party Fabric views derive their events + prop processors from RN's own ViewConfig
-// registry; `get` throws for an unregistered name, so undefined is the right answer for
-// anything the registry doesn't know (our built-ins never reach here).
-setNativeViewConfigSource(name => {
-  try {
-    return ReactNativeViewConfigRegistry.get(name);
-  } catch {
-    return undefined;
-  }
-});
-
-// Native invokes this runnable by app key with the surface's rootTag; it mounts the Vue
-// app through @symbiote-native/engine. registerRunnable (not registerComponent) means RN stores
-// a raw mount callback and never renders it with its own renderer.
-RNAppRegistry.registerRunnable(appName, ({ rootTag }) => {
-  mount(rootTag, App);
-});
+createApp(App).mount(appName);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,13 @@ importers:
       '@symbiote-native/engine':
         specifier: workspace:*
         version: link:../engine
+      react-native:
+        specifier: '>=0.86'
+        version: 0.86.0(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@6.0.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.0.0
 
   core/css-parser:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `bootstrapHost` (`@symbiote-native/components`) plus `registerApp`/`createApp`/`bootstrapApplication` per adapter, collapsing the manual native-host wiring (colors, images, device events, third-party ViewConfigs, AppRegistry) every canary previously hand-rolled into one call.
- Wire the new API into all four public `examples/*` entry points.
- Changeset included for `@symbiote-native/{components,react,vue,angular}` (minor).

## Test plan
- [x] `vitest run` on `core/components/src/bootstrap.test.ts` — 2/2 passing
- [x] `tsc --build` clean for `core/components` + `adapters/{react,vue,angular}`
- [ ] `examples/*` won't actually run against this branch yet — they resolve `@symbiote-native/*` via `catalog:` (published npm), which has no `./bootstrap` export until the next release