### PR TITLE
fix(engine): retain multi-touch presses

### DIFF
--- a/.changeset/retain-multitouch-press.md
+++ b/.changeset/retain-multitouch-press.md
@@ -1,0 +1,6 @@
+---
+'@symbiote-native/engine': patch
+---
+
+Keep synthesized presses scoped to their owning target: additional fingers inside one owner
+share one lifecycle, while unrelated targets remain independently pressable until their own final lift.

--- a/adapters/react/src/components/pressable/pressable.test.tsx
+++ b/adapters/react/src/components/pressable/pressable.test.tsx
@@ -56,12 +56,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-// The responder is the Pressable's own RCTView, the first non-box-none RCTView created.
-function responderHandle(): unknown {
+// The responder is the Pressable's own non-box-none RCTView. `testID` disambiguates multiple
+// simultaneously mounted Pressables; omitted retains the common single-Pressable lookup.
+function responderHandle(testID?: string): unknown {
   const view = fabric.find(
-    n => n.viewName === 'RCTView' && n.props.pointerEvents !== 'box-none',
+    n =>
+      n.viewName === 'RCTView' &&
+      n.props.pointerEvents !== 'box-none' &&
+      (testID === undefined || n.props.testID === testID),
   );
-  if (!view) throw new Error('no RCTView (Pressable responder) was created');
+  if (!view)
+    throw new Error('no matching RCTView (Pressable responder) was created');
   return view.instanceHandle;
 }
 
@@ -137,6 +142,122 @@ describe('React Pressable on the engine', () => {
     fire(handle, TOUCH_START);
     fire(handle, TOUCH_END);
     expect(presses).toBe(1);
+  });
+
+  it('stays active across multiple touches and completes once on the final lift', () => {
+    const order: string[] = [];
+    mount(
+      ROOT_TAG,
+      <Pressable
+        onPressIn={() => order.push('in')}
+        onPress={() => order.push('press')}
+        onPressOut={() => order.push('out')}
+      />,
+    );
+    const handle = responderHandle();
+    const first = {
+      identifier: 1,
+      pageX: 10,
+      pageY: 10,
+      timestamp: 1,
+      target: handle,
+    };
+    const second = {
+      identifier: 2,
+      pageX: 12,
+      pageY: 10,
+      timestamp: 2,
+      target: handle,
+    };
+
+    fabric.fireEvent(handle, TOUCH_START, {
+      changedTouches: [first],
+      touches: [first],
+    });
+    fabric.fireEvent(handle, TOUCH_START, {
+      changedTouches: [second],
+      touches: [first, second],
+    });
+    expect(order).toEqual(['in']);
+
+    fabric.fireEvent(handle, TOUCH_END, {
+      changedTouches: [first],
+      touches: [second],
+    });
+    expect(order).toEqual(['in']);
+
+    fabric.fireEvent(handle, TOUCH_END, {
+      changedTouches: [second],
+      touches: [],
+    });
+    // The engine completes on the final lift. A higher-level Pressable implementation may retain
+    // its active visual/onPressOut for RN's 130ms minimum duration, so assert completion by that
+    // boundary rather than requiring a synchronous adapter callback.
+    vi.advanceTimersByTime(130);
+    expect(order).toEqual(['in', 'press', 'out']);
+  });
+
+  it('keeps simultaneous sibling Pressables independent', () => {
+    const firstOrder: string[] = [];
+    const siblingOrder: string[] = [];
+    mount(
+      ROOT_TAG,
+      <>
+        <Pressable
+          testID="first"
+          onPressIn={() => firstOrder.push('in')}
+          onPress={() => firstOrder.push('press')}
+          onPressOut={() => firstOrder.push('out')}
+        />
+        <Pressable
+          testID="sibling"
+          onPressIn={() => siblingOrder.push('in')}
+          onPress={() => siblingOrder.push('press')}
+          onPressOut={() => siblingOrder.push('out')}
+        />
+      </>,
+    );
+    const firstHandle = responderHandle('first');
+    const siblingHandle = responderHandle('sibling');
+    const first = {
+      identifier: 1,
+      pageX: 10,
+      pageY: 10,
+      timestamp: 1,
+      target: firstHandle,
+    };
+    const sibling = {
+      identifier: 2,
+      pageX: 30,
+      pageY: 10,
+      timestamp: 2,
+      target: siblingHandle,
+    };
+
+    fabric.fireEvent(firstHandle, TOUCH_START, {
+      changedTouches: [first],
+      touches: [first],
+    });
+    fabric.fireEvent(siblingHandle, TOUCH_START, {
+      changedTouches: [sibling],
+      touches: [first, sibling],
+    });
+    expect(firstOrder).toEqual(['in']);
+    expect(siblingOrder).toEqual(['in']);
+
+    fabric.fireEvent(siblingHandle, TOUCH_END, {
+      changedTouches: [sibling],
+      touches: [first],
+    });
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
+    expect(firstOrder).toEqual(['in']);
+    expect(siblingOrder).toEqual(['in', 'press', 'out']);
+
+    fabric.fireEvent(firstHandle, TOUCH_END, {
+      changedTouches: [first],
+      touches: [],
+    });
+    expect(firstOrder).toEqual(['in', 'press', 'out']);
   });
 
   // why: RN's disabled Pressable must not claim the responder or fire feedback at all — a

--- a/core/engine/src/events/events.test.ts
+++ b/core/engine/src/events/events.test.ts
@@ -220,6 +220,53 @@ describe('pressIn / pressOut synthesis', () => {
     expect(firstOrder).toEqual(['in', 'press', 'out']);
   });
 
+  // why: Android can cancel one pointer while another stays active. Cancellation must release only
+  // the owner that lost its final touch; a sibling press and responder remain live.
+  it('scopes touch cancellation to owners without a remaining touch', () => {
+    const firstOrder: string[] = [];
+    const siblingOrder: string[] = [];
+    const responderOrder: string[] = [];
+    routeProp(tree.button, 'onPressIn', () => firstOrder.push('in'));
+    routeProp(tree.button, 'onPress', () => firstOrder.push('press'));
+    routeProp(tree.button, 'onPressOut', () => firstOrder.push('out'));
+    routeProp(tree.sibling, 'onPressIn', () => siblingOrder.push('in'));
+    routeProp(tree.sibling, 'onPressOut', () => siblingOrder.push('out'));
+    routeProp(tree.button, 'onStartShouldSetResponder', () => true);
+    routeProp(tree.button, 'onResponderEnd', () => responderOrder.push('end'));
+    routeProp(tree.button, 'onResponderRelease', () =>
+      responderOrder.push('release'),
+    );
+    routeProp(tree.button, 'onResponderTerminate', () =>
+      responderOrder.push('terminate'),
+    );
+
+    const first = { identifier: 1, target: tree.button };
+    const sibling = { identifier: 2, target: tree.sibling };
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [first],
+      touches: [first],
+    });
+    fabric.fireEvent(tree.sibling, 'topTouchStart', {
+      changedTouches: [sibling],
+      touches: [first, sibling],
+    });
+
+    fabric.fireEvent(tree.sibling, 'topTouchCancel', {
+      changedTouches: [sibling],
+      touches: [first],
+    });
+    expect(firstOrder).toEqual(['in']);
+    expect(siblingOrder).toEqual(['in', 'out']);
+    expect(responderOrder).toEqual(['end']);
+
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [first],
+      touches: [],
+    });
+    expect(firstOrder).toEqual(['in', 'press', 'out']);
+    expect(responderOrder).toEqual(['end', 'end', 'release']);
+  });
+
   it('fires pressOut on the start node even when the touch ends elsewhere', () => {
     let pressedOut = 0;
     routeProp(tree.button, 'onPressOut', () => {
@@ -631,10 +678,8 @@ describe('ViewConfig gate', () => {
 });
 
 describe('responder negotiation (PanResponder protocol)', () => {
-  // pressStart/currentResponder/longPressTimer are module-scoped state, not per-test --
-  // installEventHandler() runs once at file scope. Force-clear via a real cancel dispatch
-  // (which unconditionally resets both, see events/index.ts's TOUCH_CANCEL branch) so a
-  // touch left mid-gesture by one test can never leak into the next.
+  // Press/responder state is module-scoped, not per-test. Force-clear via a cancel event with no
+  // remaining `touches`, so a deliberately partial gesture cannot leak into the next test.
   afterEach(() => {
     fabric.fireEvent(tree.root, 'topTouchCancel');
   });
@@ -745,9 +790,8 @@ describe('responder negotiation (PanResponder protocol)', () => {
     expect(order).toEqual(['end', 'release']);
   });
 
-  // why: a cancelled gesture (topTouchCancel) unconditionally releases the
-  // responder -- it must fire responderEnd then responderTerminate, never responderRelease
-  // (the responder wasn't released by finishing, it was taken away).
+  // why: cancelling the responder's final touch fires responderEnd then responderTerminate, never
+  // responderRelease (the responder was taken away rather than released by finishing).
   it('fires responderEnd then responderTerminate on topTouchCancel', () => {
     const order: string[] = [];
     routeProp(tree.button, 'onStartShouldSetResponder', () => true);

--- a/core/engine/src/events/events.test.ts
+++ b/core/engine/src/events/events.test.ts
@@ -51,6 +51,11 @@ let tree: ITree;
 beforeEach(() => {
   tree = buildTree();
 });
+afterEach(() => {
+  // The event layer is a process singleton. End any deliberately partial gesture so one test's
+  // responder/press ownership cannot become the next test's hidden baseline.
+  fabric.fireEvent(tree.button, 'topTouchCancel');
+});
 
 describe('press correlation', () => {
   // why: a tap is only "honest" when the finger lifts on the node it went down on
@@ -119,6 +124,102 @@ describe('pressIn / pressOut synthesis', () => {
 
   // why: pressOut must fire on the node the touch STARTED on (the responder) even
   // when the honest-tap check fails, so the pressed-state visual always releases.
+  it('keeps one press active until the final touch inside it lifts', () => {
+    const order: string[] = [];
+    routeProp(tree.button, 'onPressIn', () => order.push('in'));
+    routeProp(tree.button, 'onPress', () => order.push('press'));
+    routeProp(tree.button, 'onPressOut', () => order.push('out'));
+
+    const first = {
+      identifier: 1,
+      pageX: 10,
+      pageY: 10,
+      timestamp: 1,
+      target: tree.button,
+    };
+    const second = {
+      identifier: 2,
+      pageX: 12,
+      pageY: 10,
+      timestamp: 2,
+      target: tree.button,
+    };
+
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [first],
+      touches: [first],
+    });
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [second],
+      touches: [first, second],
+    });
+    expect(order).toEqual(['in']);
+
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [first],
+      touches: [second],
+    });
+    expect(order).toEqual(['in']);
+
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [second],
+      touches: [],
+    });
+    expect(order).toEqual(['in', 'press', 'out']);
+  });
+
+  // why: touch count alone conflates two fingers on one Pressable with fingers on two unrelated
+  // Pressables. Each owner must complete its own lifecycle regardless of which finger lifts first.
+  it('keeps simultaneous presses on sibling targets independent', () => {
+    const firstOrder: string[] = [];
+    const siblingOrder: string[] = [];
+    routeProp(tree.button, 'onPressIn', () => firstOrder.push('in'));
+    routeProp(tree.button, 'onPress', () => firstOrder.push('press'));
+    routeProp(tree.button, 'onPressOut', () => firstOrder.push('out'));
+    routeProp(tree.sibling, 'onPressIn', () => siblingOrder.push('in'));
+    routeProp(tree.sibling, 'onPress', () => siblingOrder.push('press'));
+    routeProp(tree.sibling, 'onPressOut', () => siblingOrder.push('out'));
+
+    const first = {
+      identifier: 1,
+      pageX: 10,
+      pageY: 10,
+      timestamp: 1,
+      target: tree.button,
+    };
+    const sibling = {
+      identifier: 2,
+      pageX: 30,
+      pageY: 10,
+      timestamp: 2,
+      target: tree.sibling,
+    };
+
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [first],
+      touches: [first],
+    });
+    fabric.fireEvent(tree.sibling, 'topTouchStart', {
+      changedTouches: [sibling],
+      touches: [first, sibling],
+    });
+    expect(firstOrder).toEqual(['in']);
+    expect(siblingOrder).toEqual(['in']);
+
+    fabric.fireEvent(tree.sibling, 'topTouchEnd', {
+      changedTouches: [sibling],
+      touches: [first],
+    });
+    expect(firstOrder).toEqual(['in']);
+    expect(siblingOrder).toEqual(['in', 'press', 'out']);
+
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [first],
+      touches: [],
+    });
+    expect(firstOrder).toEqual(['in', 'press', 'out']);
+  });
+
   it('fires pressOut on the start node even when the touch ends elsewhere', () => {
     let pressedOut = 0;
     routeProp(tree.button, 'onPressOut', () => {
@@ -185,6 +286,53 @@ describe('longPress synthesis', () => {
     fabric.fireEvent(tree.button, 'topTouchEnd');
     // why: RN eats the tap once a long press has already fired for the same gesture --
     // otherwise a long-press would ALSO register as a regular press on release.
+    expect(presses).toBe(0);
+  });
+
+  it('does not restart the long-press clock when another finger joins', () => {
+    let longPresses = 0;
+    let presses = 0;
+    routeProp(tree.button, 'onLongPress', () => {
+      longPresses += 1;
+    });
+    routeProp(tree.button, 'onPress', () => {
+      presses += 1;
+    });
+    const first = {
+      identifier: 1,
+      pageX: 0,
+      pageY: 0,
+      timestamp: 1,
+      target: tree.button,
+    };
+    const second = {
+      identifier: 2,
+      pageX: 1,
+      pageY: 0,
+      timestamp: 2,
+      target: tree.button,
+    };
+
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [first],
+      touches: [first],
+    });
+    vi.advanceTimersByTime(300);
+    fabric.fireEvent(tree.button, 'topTouchStart', {
+      changedTouches: [second],
+      touches: [first, second],
+    });
+    vi.advanceTimersByTime(200);
+    expect(longPresses).toBe(1);
+
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [first],
+      touches: [second],
+    });
+    fabric.fireEvent(tree.button, 'topTouchEnd', {
+      changedTouches: [second],
+      touches: [],
+    });
     expect(presses).toBe(0);
   });
 

--- a/core/engine/src/events/index.ts
+++ b/core/engine/src/events/index.ts
@@ -517,16 +517,29 @@ export function installEventHandler(): void {
       if (topLevelType === TOUCH_CANCEL) {
         recordTouchTrack('end', nativeEvent);
         attachTouchHistory(nativeEvent);
-        const cancelledPresses = takeAllPresses();
+        // A cancel is scoped to the finger(s) removed from `touches`, just like an end. An unrelated
+        // Pressable—or another finger under the same owner—must keep its press and long-press state.
+        const cancelledPresses: IPressGesture[] = [];
+        for (const press of activePresses) {
+          if (hasRemainingTouchWithin(press.owner, nativeEvent)) continue;
+          activePresses.delete(press);
+          clearLongPress(press);
+          cancelledPresses.push(press);
+        }
         const responder = currentResponder;
-        currentResponder = undefined;
+        const terminatesResponder =
+          responder !== undefined &&
+          !hasRemainingTouchWithin(responder, nativeEvent);
+        if (terminatesResponder) currentResponder = undefined;
         runWrapped(() => {
           for (const press of cancelledPresses)
             bubble(press.owner, PRESS_OUT, nativeEvent);
-          // A cancelled gesture ends then terminates (the responder was taken away).
           if (responder) {
+            // Like touch-end, every finger leaving emits responderEnd. Termination is final only
+            // when no touch remains inside the responder.
             callOwnListener(responder, RESPONDER_END, nativeEvent);
-            callOwnListener(responder, RESPONDER_TERMINATE, nativeEvent);
+            if (terminatesResponder)
+              callOwnListener(responder, RESPONDER_TERMINATE, nativeEvent);
           }
         });
         if (touchHistory.numberActiveTouches === 0) resetTouchHistory();

--- a/core/engine/src/events/index.ts
+++ b/core/engine/src/events/index.ts
@@ -108,36 +108,44 @@ const LONG_PRESS_DEACTIVATION_DISTANCE = 10;
 
 let installed = false;
 
-// Target of the in-flight touch, remembered at topTouchStart and consumed (or
-// cleared) at topTouchEnd / topTouchCancel.
-let pressStart: ISymbioteNode | undefined;
+interface IPressGesture {
+  owner: ISymbioteNode;
+  longPressTimer: ReturnType<typeof setTimeout> | undefined;
+  longPressFired: boolean;
+  longPressStart: { x: number; y: number } | undefined;
+}
+
+// Each unrelated target owns an independent press. Additional fingers under the same owner join
+// that press, so one target still receives exactly one pressIn/press/pressOut lifecycle.
+const activePresses = new Set<IPressGesture>();
 
 // The node that claimed the responder for the in-flight touch (PanResponder), or
 // undefined when nobody claimed it. Receives move and release/terminate.
 let currentResponder: ISymbioteNode | undefined;
 
-// Long-press synthesis: armed at touch start when some node in the press path listens
-// for it, fired once after the hold delay, disarmed on end/cancel; the same arm/clear
-// lifecycle Pressable runs in JS. Pressability ALSO cancels the timer when the touch
-// drifts past LONG_PRESS_DEACTIVATION_DISTANCE, so we record the start point at touch
-// start and clear the timer on a move that exceeds it.
-let longPressTimer: ReturnType<typeof setTimeout> | undefined;
-let longPressFired = false;
-// Touch coordinate at touch start (pageX/pageY), or undefined when the native event
-// carried no coords; then the move-distance cancel is simply skipped.
-let longPressStart: { x: number; y: number } | undefined;
-
-function clearLongPress(): void {
-  if (longPressTimer !== undefined) {
-    clearTimeout(longPressTimer);
-    longPressTimer = undefined;
+function clearLongPress(press: IPressGesture): void {
+  if (press.longPressTimer !== undefined) {
+    clearTimeout(press.longPressTimer);
+    press.longPressTimer = undefined;
   }
 }
 
-// Read the gesture's page coordinate from a raw native touch event, defensively: RN
-// puts pageX/pageY on the event for a single touch, or on the first entry of a
-// `touches` array for multi-touch. Returns undefined when neither shape carries
-// numbers, so callers skip any coordinate-dependent logic rather than guess.
+function takeAllPresses(): IPressGesture[] {
+  const presses = [...activePresses];
+  activePresses.clear();
+  for (const press of presses) clearLongPress(press);
+  return presses;
+}
+
+function findActivePress(target: ISymbioteNode): IPressGesture | undefined {
+  for (const press of activePresses) {
+    if (endsWithin(target, press.owner)) return press;
+  }
+  return undefined;
+}
+
+// Read the changed finger's page coordinate from a raw native touch event, falling back to the
+// active-touch list and then undefined. Callers skip coordinate-dependent logic rather than guess.
 function readTouchPoint(
   nativeEvent: Record<string, unknown>,
 ): { x: number; y: number } | undefined {
@@ -152,22 +160,26 @@ function readTouchPoint(
   };
   const direct = fromPair(nativeEvent);
   if (direct) return direct;
-  const touches = nativeEvent.touches;
-  if (Array.isArray(touches)) {
-    const first = touches[0];
-    if (isRecord(first)) return fromPair(first);
+  // `changedTouches` identifies the finger for this frame. Read it before the full active-touch
+  // list, whose first entry may belong to another simultaneously pressed target.
+  for (const key of ['changedTouches', 'touches'] as const) {
+    const touches = nativeEvent[key];
+    if (!Array.isArray(touches)) continue;
+    for (const touch of touches) {
+      if (!isRecord(touch)) continue;
+      const point = fromPair(touch);
+      if (point) return point;
+    }
   }
   return undefined;
 }
 
-// Whether any touch still down started inside the responder (its target IS the
-// responder or a descendant). RN's noResponderTouches walks nativeEvent.touches and
-// returns false the moment one is found; a release fires only when none remain. The
-// headless smokes fire with an empty `{}` event (no `touches`) -> no remaining touch ->
-// release fires, preserving single-touch behavior. (ResponderEventPlugin.noResponder-
-// Touches + isAncestor.)
-function hasRemainingResponderTouch(
-  responder: ISymbioteNode,
+// Whether any touch still down started inside an owner (its target IS the owner or a descendant).
+// RN's noResponderTouches walks nativeEvent.touches and returns false the moment one is found; a
+// responder release and our synthesized press completion both wait until none remain. The headless
+// smokes fire with an empty `{}` event -> no remaining touch -> preserve single-touch behavior.
+function hasRemainingTouchWithin(
+  owner: ISymbioteNode,
   nativeEvent: Record<string, unknown>,
 ): boolean {
   const touches = nativeEvent.touches;
@@ -175,7 +187,7 @@ function hasRemainingResponderTouch(
   for (const touch of touches) {
     if (!isRecord(touch)) continue;
     const target = touch.target;
-    if (isSymbioteNode(target) && endsWithin(target, responder)) return true;
+    if (isSymbioteNode(target) && endsWithin(target, owner)) return true;
   }
   return false;
 }
@@ -372,23 +384,39 @@ export function installEventHandler(): void {
         // read each touch's own previous->current delta; RN records before dispatch.
         recordTouchTrack('start', nativeEvent);
         attachTouchHistory(nativeEvent);
-        pressStart = instanceHandle;
-        // Arm long-press synthesis: only when a listener exists in the path, fired once
-        // after the hold delay, then suppresses the tap (longPressFired) on release.
-        longPressFired = false;
-        clearLongPress();
-        longPressStart = readTouchPoint(nativeEvent);
-        if (hasListenerInPath(instanceHandle, LONG_PRESS)) {
-          const longPressTarget = instanceHandle;
-          longPressTimer = setTimeout(() => {
-            longPressTimer = undefined;
-            longPressFired = true;
-            dlog('synthesized longPress -> dispatch');
-            runWrapped(() => bubble(longPressTarget, LONG_PRESS, nativeEvent));
-          }, DEFAULT_LONG_PRESS_MS);
+        const canJoinExistingPress =
+          Array.isArray(nativeEvent.touches) && nativeEvent.touches.length > 1;
+        const joinedPress = canJoinExistingPress
+          ? findActivePress(instanceHandle)
+          : undefined;
+        // A one-touch or identifier-less frame starts a new physical gesture. Any surviving press
+        // is stale (its end/cancel was lost), so release it instead of letting it suppress this start.
+        const stalePresses = canJoinExistingPress ? [] : takeAllPresses();
+        let startedPress: IPressGesture | undefined;
+        if (joinedPress === undefined) {
+          startedPress = {
+            owner: instanceHandle,
+            longPressTimer: undefined,
+            longPressFired: false,
+            longPressStart: readTouchPoint(nativeEvent),
+          };
+          activePresses.add(startedPress);
+          if (hasListenerInPath(instanceHandle, LONG_PRESS)) {
+            const press = startedPress;
+            press.longPressTimer = setTimeout(() => {
+              if (!activePresses.has(press)) return;
+              press.longPressTimer = undefined;
+              press.longPressFired = true;
+              dlog('synthesized longPress -> dispatch');
+              runWrapped(() => bubble(press.owner, LONG_PRESS, nativeEvent));
+            }, DEFAULT_LONG_PRESS_MS);
+          }
         }
         runWrapped(() => {
-          bubble(instanceHandle, PRESS_IN, nativeEvent);
+          for (const stale of stalePresses)
+            bubble(stale.owner, PRESS_OUT, nativeEvent);
+          if (startedPress) bubble(startedPress.owner, PRESS_IN, nativeEvent);
+          else dlog('pressIn retained (another touch joined the active press)');
           // Responder negotiation runs alongside press synthesis: a View can be both
           // a Pressable (press) and a PanResponder target (responder).
           negotiateResponder(instanceHandle, 'start', nativeEvent);
@@ -402,16 +430,20 @@ export function installEventHandler(): void {
       if (topLevelType === TOUCH_MOVE) {
         recordTouchTrack('move', nativeEvent);
         attachTouchHistory(nativeEvent);
-        // Cancel the pending long press if the touch drifted too far (Pressability's
-        // deactivation-distance check). Skipped when either coord is unknown.
-        if (longPressTimer !== undefined && longPressStart) {
+        // Only the press owning this move can lose its long-press timer; movement on an unrelated
+        // simultaneously held Pressable must not disturb another target's clock.
+        const movedPress = findActivePress(instanceHandle);
+        if (
+          movedPress?.longPressTimer !== undefined &&
+          movedPress.longPressStart
+        ) {
           const here = readTouchPoint(nativeEvent);
           if (here) {
-            const dx = here.x - longPressStart.x;
-            const dy = here.y - longPressStart.y;
+            const dx = here.x - movedPress.longPressStart.x;
+            const dy = here.y - movedPress.longPressStart.y;
             if (Math.hypot(dx, dy) > LONG_PRESS_DEACTIVATION_DISTANCE) {
               dlog('longPress cancelled (moved past deactivation distance)');
-              clearLongPress();
+              clearLongPress(movedPress);
             }
           }
         }
@@ -429,8 +461,14 @@ export function installEventHandler(): void {
       if (topLevelType === TOUCH_END) {
         recordTouchTrack('end', nativeEvent);
         attachTouchHistory(nativeEvent);
-        const start = pressStart;
-        pressStart = undefined;
+        const hadActivePress = activePresses.size > 0;
+        const completedPresses: IPressGesture[] = [];
+        for (const press of activePresses) {
+          if (hasRemainingTouchWithin(press.owner, nativeEvent)) continue;
+          activePresses.delete(press);
+          clearLongPress(press);
+          completedPresses.push(press);
+        }
         const responder = currentResponder;
         // RN releases (and clears) the responder only when no remaining touch still down
         // started inside it; lifting ONE finger in a multi-touch gesture must NOT release.
@@ -438,28 +476,26 @@ export function installEventHandler(): void {
         // is unconditional, responderRelease is gated on noResponderTouches.)
         const releases =
           responder !== undefined &&
-          !hasRemainingResponderTouch(responder, nativeEvent);
+          !hasRemainingTouchWithin(responder, nativeEvent);
         if (releases) currentResponder = undefined;
-        // A completed long press eats the tap (RN), but pressOut still fires below.
-        const wasLongPress = longPressFired;
-        longPressFired = false;
-        longPressStart = undefined;
-        clearLongPress();
         runWrapped(() => {
-          if (start) {
-            // press fires only on an honest tap (ended within the responder); pressOut
-            // always fires on the responder so its pressed-state can release.
-            if (endsWithin(instanceHandle, start)) {
-              if (wasLongPress) {
+          for (const press of completedPresses) {
+            // Each target completes independently. An honest tap ends inside that target; pressOut
+            // always releases its pressed state, including a drag-away end.
+            if (endsWithin(instanceHandle, press.owner)) {
+              if (press.longPressFired) {
                 dlog('press suppressed (longPress already fired)');
               } else {
                 dlog('event press -> dispatch');
-                bubble(start, PRESS, nativeEvent);
+                bubble(press.owner, PRESS, nativeEvent);
               }
             }
-            bubble(start, PRESS_OUT, nativeEvent);
-          } else {
+            bubble(press.owner, PRESS_OUT, nativeEvent);
+          }
+          if (!hadActivePress) {
             dlog(`event ${TOUCH_END} ignored (no matching start)`);
+          } else if (completedPresses.length === 0) {
+            dlog('press retained (another touch remains inside its owner)');
           }
           // onResponderEnd fires on every finger-up; onResponderRelease (the final
           // release) only when the last responder touch lifted.
@@ -481,15 +517,12 @@ export function installEventHandler(): void {
       if (topLevelType === TOUCH_CANCEL) {
         recordTouchTrack('end', nativeEvent);
         attachTouchHistory(nativeEvent);
-        const start = pressStart;
-        pressStart = undefined;
+        const cancelledPresses = takeAllPresses();
         const responder = currentResponder;
         currentResponder = undefined;
-        longPressFired = false;
-        longPressStart = undefined;
-        clearLongPress();
         runWrapped(() => {
-          if (start) bubble(start, PRESS_OUT, nativeEvent);
+          for (const press of cancelledPresses)
+            bubble(press.owner, PRESS_OUT, nativeEvent);
           // A cancelled gesture ends then terminates (the responder was taken away).
           if (responder) {
             callOwnListener(responder, RESPONDER_END, nativeEvent);


### PR DESCRIPTION
## Summary

- scope synthesized press state per owning target instead of globally
- let additional fingers inside one owner share a single lifecycle without duplicate `pressIn` or long-press timer restarts
- keep simultaneous sibling Pressables independent so each completes on its own final lift
- isolate long-press movement/cancellation state per active press
- add engine and React adapter regression coverage plus a patch changeset

## Test coverage

- `core/engine/src/events/events.test.ts`
- `adapters/react/src/components/pressable/pressable.test.tsx`