### PR TITLE
fix(components): harden Pressable lifecycle

### DIFF
--- a/.changeset/pressable-lifecycle-contract.md
+++ b/.changeset/pressable-lifecycle-contract.md
@@ -1,0 +1,12 @@
+---
+'@symbiote-native/components': patch
+'@symbiote-native/react': patch
+'@symbiote-native/vue': patch
+'@symbiote-native/svelte': patch
+'@symbiote-native/angular': patch
+'@symbiote-native/solid': patch
+---
+
+Match React Native Pressability's delayed activation, retention-region re-entry, 130 ms plain
+Pressable active-duration floor, Touchable zero-floor override, and timer cleanup on framework
+teardown across all five adapters.

--- a/.claude/skills/symbiote-parity-check/SKILL.md
+++ b/.claude/skills/symbiote-parity-check/SKILL.md
@@ -253,10 +253,12 @@ adapters, why it was not fixed, and what would prove the fix.
 
 ### Open — Touchable family (audit 2026-08-19)
 
-- **pressIn duration on responder grant.** RN fades over 0 ms when the press-in arrives with the
-  grant and 150 ms otherwise; we always use 150. UNREACHABLE today: the branch needs
-  `event.dispatchConfig.registrationName`, which our Pressable does not emit. Fixing it means
-  widening the event payload — an engine change, not an adapter one.
+- **Touchable re-entry opacity duration.** The shared Pressable machine now deactivates when a
+  touch leaves its retention region and re-activates (including a second `onPressIn`) when it
+  returns. TouchableOpacity still applies its grant duration, 0 ms, to both activations. RN uses
+  0 ms for the initial responder grant but 150 ms for drift-back-in. Closing the final visual
+  difference needs the shared machine to expose the activation reason (`grant` vs `re-entry`) to
+  the Touchable feedback callback; widening the public event payload is unnecessary.
 - **Underlay style distribution.** RN puts `opacity` on the CHILD and `backgroundColor` on the
   container (`TouchableHighlight.js`). React (`cloneElement`) and Vue (`cloneVNode`) now do this
   and were verified to insert no extra node. **Angular and Solid still put both on the container**
@@ -270,24 +272,6 @@ adapters, why it was not fixed, and what would prove the fix.
   `resetAnimation()` on teardown (root teardown already stops the leaf, so a test greens on broken
   code too — one was written, proved vacuous, and deleted); and the visual→callback ORDER on
   Angular (the visual only reaches the tree on a later async CD pass).
-- **No drift-back-in re-activation — all five adapters.** RN's Pressability has a state
-  `RESPONDER_INACTIVE_PRESS_OUT` and transitions back to `RESPONDER_ACTIVE_PRESS_IN` when the
-  finger leaves the retention region and returns, re-firing `onPressIn` (over 150 ms, not 0 —
-  that is the branch `OPACITY_ACTIVE_DURATION_MS` still exists for). Our engine dispatches
-  `pressIn` from exactly one place, `core/engine/src/events/index.ts:391` on topTouchStart, and
-  has no re-activation path at all: once the press drifts out, only pressOut can follow. Closing
-  this is a press-STATE-MACHINE change (`core/components/src/state/pressable.ts` plus the engine's
-  move stream), not an event-payload one — an earlier reading of this gap blamed a missing
-  `dispatchConfig.registrationName` and proposed widening `ISymbioteEvent`, which would not have
-  helped: with one origin the field would always carry the same value.
-- **Press timers are never cancelled on unmount — React, Vue, Angular, Svelte.** Found 2026-08-19
-  while migrating Svelte, OUTSIDE the original ten. `scheduleTimeout` returns a canceller and the
-  shared machine stores it (`runtime.pressDelayCancel`), but nothing calls it when the component
-  goes away: a pending `unstable_pressDelay` timer fires into an unmounted component, calling
-  `onPressIn` and starting an animation on a dead leaf. **Solid is the only adapter that closed
-  this**, via a `createTimeoutScheduler()` that keeps a Set of cancellers and clears them in
-  `onCleanup`. Port that shape to the other four. A test for it was written during the Svelte pass,
-  failed, and was DELETED rather than weakened — write it again with the fix.
 - **A stale header claiming an impossibility cost real work, twice in one day.** Svelte's
   TouchableOpacity carried a homemade `tweenOpacity` over `setTimeout` and a header stating this
   adapter has no Animated binding — untrue since `modules/animated` landed, so `useNativeDriver`
@@ -295,12 +279,6 @@ adapters, why it was not fixed, and what would prove the fix.
   namespace header claimed a generic `createAnimatedComponent` was impossible; a four-line probe
   refuted it. Treat any header sentence of the form "X is impossible on this adapter" as an
   untested claim with a date attached, not a finding.
-- **`Pressable` has no `minPressDuration` at all.** Surfaced by deleting
-  `DEFAULT_MIN_PRESS_DURATION_MS` (2026-08-19, once all five adapters had migrated): the constant
-  turned out to have NO production consumer — `core/components/src/state/pressable.ts` never
-  implements a press-duration floor, so RN's 130 ms Pressability default is simply absent for a
-  plain `Pressable`. The Touchable family is correct without it (RN overrides it with 0 there),
-  but a plain Pressable in RN does hold the active visual for 130 ms and ours does not.
 
 ### How to run a conformance pass on a component
 

--- a/adapters/angular/src/components/pressable/index.ts
+++ b/adapters/angular/src/components/pressable/index.ts
@@ -13,11 +13,14 @@ import {
   ViewChild,
   type DoCheck,
   type OnChanges,
+  type OnDestroy,
 } from '@angular/core';
 import {
   createPressHandlers,
   createPressRuntime,
+  disposePressRuntime,
   DEFAULT_DELAY_LONG_PRESS_MS,
+  DEFAULT_MIN_PRESS_DURATION_MS,
   isTerminationAllowed,
   resolveAccessibilityProps,
   resolveDisabledAccessibilityState,
@@ -150,7 +153,9 @@ function asSymbioteEvent(event: unknown): ISymbioteEvent | undefined {
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Pressable implements IAngularPressableInputs, OnChanges, DoCheck {
+export class Pressable
+  implements IAngularPressableInputs, OnChanges, OnDestroy, DoCheck
+{
   // The press/hover lifecycle as real Angular events: `(press)="onTap($event)"`, not
   // `[onPress]="onTap"`. createPressHandlers still wants plain IPressHandler callbacks, so
   // emitterHandler() below adapts each EventEmitter into one - only while something is actually
@@ -176,6 +181,8 @@ export class Pressable implements IAngularPressableInputs, OnChanges, DoCheck {
   @Input() hitSlop?: IRectOffset;
   @Input() pressRetentionOffset?: IRectOffset;
   @Input() unstable_pressDelay?: number;
+  /** @internal Touchable* mirrors RN's Pressability minPressDuration: 0 override. */
+  @Input() __minPressDuration = DEFAULT_MIN_PRESS_DURATION_MS;
   @Input() android_ripple?: IPressableAndroidRippleConfig;
   @Input() android_disableSound?: boolean;
   @Input() delayHoverIn?: number;
@@ -255,6 +262,7 @@ export class Pressable implements IAngularPressableInputs, OnChanges, DoCheck {
       const id = setTimeout(callback, ms);
       return () => clearTimeout(id);
     },
+    now: Date.now,
   };
 
   private readonly changeDetector = inject(ChangeDetectorRef);
@@ -287,6 +295,10 @@ export class Pressable implements IAngularPressableInputs, OnChanges, DoCheck {
   // write registers no dependency on the caller's view and cannot throw NG0600.
   ngDoCheck(): void {
     this.anchorStyle.set(anchorHostStyle(this.elementRef));
+  }
+
+  ngOnDestroy(): void {
+    disposePressRuntime(this.runtime);
   }
 
   ngOnChanges(): void {
@@ -449,6 +461,7 @@ export class Pressable implements IAngularPressableInputs, OnChanges, DoCheck {
       onLongPress: this.emitterHandler(this.longPress),
       delayLongPress: this.delayLongPress ?? DEFAULT_DELAY_LONG_PRESS_MS,
       unstable_pressDelay: this.unstable_pressDelay ?? 0,
+      minPressDuration: this.__minPressDuration,
       hitSlop: this.hitSlop,
       pressRetentionOffset: this.pressRetentionOffset,
     };

--- a/adapters/angular/src/components/pressable/pressable.test.ts
+++ b/adapters/angular/src/components/pressable/pressable.test.ts
@@ -8,6 +8,7 @@ import '@angular/compiler';
 import { Component, signal } from '@angular/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearGlobalStyles, registerRules } from '@symbiote-native/engine';
+import { DEFAULT_MIN_PRESS_DURATION_MS } from '@symbiote-native/components';
 import { installFabric, type IFakeNode } from '@symbiote-native/test-utils';
 
 import { mount, unmount } from '../../render';
@@ -46,8 +47,32 @@ class PressableHost {
   }
 }
 
+let delayedHost: DelayedPressableHost | undefined;
+
+@Component({
+  selector: 'symbiote-delayed-pressable-host',
+  standalone: true,
+  imports: [Pressable],
+  template: `
+    <Pressable
+      [testID]="'delayed-pressable'"
+      [unstable_pressDelay]="30"
+      (pressIn)="onPressIn($event)"
+    ></Pressable>
+  `,
+})
+class DelayedPressableHost {
+  onPressIn = vi.fn();
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    delayedHost = this;
+  }
+}
+
 beforeEach(() => {
   capturedHost = undefined;
+  delayedHost = undefined;
   fabric.reset();
 });
 afterEach(() => {
@@ -78,7 +103,25 @@ describe('Pressable (no throwing path — see file header)', () => {
     await new Promise<void>(resolve => setTimeout(resolve, 0));
 
     expect(capturedHost?.onPress).toHaveBeenCalledOnce();
+    expect(capturedHost?.onPressOut).not.toHaveBeenCalled();
+    await new Promise<void>(resolve =>
+      setTimeout(resolve, DEFAULT_MIN_PRESS_DURATION_MS + 10),
+    );
     expect(capturedHost?.onPressOut).toHaveBeenCalledOnce();
+  });
+
+  it('cancels a pending press delay when Angular destroys the component', async () => {
+    mount(ROOT_TAG, DelayedPressableHost);
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    const node = fabric.find(n => n.props.testID === 'delayed-pressable');
+    expect(node).toBeDefined();
+
+    fabric.fireEvent(node?.instanceHandle, 'topTouchStart');
+    unmount(ROOT_TAG);
+    await new Promise<void>(resolve => setTimeout(resolve, 40));
+    expect(delayedHost?.onPressIn).not.toHaveBeenCalled();
+    // Clear the process-global responder only after proving ngOnDestroy cancelled the timer.
+    fabric.fireEvent(node?.instanceHandle, 'topTouchCancel');
   });
 
   it('resolves a class= on the Pressable use site onto the real committed view, not the anchor', async () => {

--- a/adapters/angular/src/components/touchable-native-feedback/index.ts
+++ b/adapters/angular/src/components/touchable-native-feedback/index.ts
@@ -82,6 +82,7 @@ export type IAngularTouchableNativeFeedbackProps = Omit<
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <Pressable
+      [__minPressDuration]="0"
       (press)="press.emit($event)"
       (pressIn)="pressIn.emit($event)"
       (pressOut)="pressOut.emit($event)"

--- a/adapters/angular/src/components/touchable/index.ts
+++ b/adapters/angular/src/components/touchable/index.ts
@@ -136,6 +136,7 @@ function createTimerScheduler(): ITimerScheduler {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <Pressable
+      [__minPressDuration]="0"
       (press)="press.emit($event)"
       (pressIn)="handlePressIn($event)"
       (pressOut)="handlePressOut($event)"
@@ -424,6 +425,7 @@ export class TouchableOpacity
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <Pressable
+      [__minPressDuration]="0"
       [style]="containerStyle()"
       (press)="handlePress($event)"
       (pressIn)="handlePressIn($event)"
@@ -700,6 +702,7 @@ export class TouchableHighlight
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <Pressable
+      [__minPressDuration]="0"
       [style]="mergedStyle"
       (press)="press.emit($event)"
       (pressIn)="handlePressIn($event)"

--- a/adapters/react/src/__tests__/clone-prop-removal.test.tsx
+++ b/adapters/react/src/__tests__/clone-prop-removal.test.tsx
@@ -8,7 +8,8 @@
 // Pressable whose pressed style sets opacity:0.2 fully drops opacity on release.
 
 import { createElement, useState, type ReactElement } from 'react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_MIN_PRESS_DURATION_MS } from '@symbiote-native/components';
 import { Pressable, Text, View, mount, unmount } from '@symbiote-native/react';
 
 interface IFakeNode {
@@ -132,9 +133,13 @@ function findByTestId(nodes: IFakeNode[], id: string): IFakeNode | undefined {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
   committed = [];
 });
-afterEach(() => unmount(ROOT_TAG));
+afterEach(() => {
+  unmount(ROOT_TAG);
+  vi.useRealTimers();
+});
 
 describe('clone-on-write prop removal', () => {
   // Positive only: this is a regression on the commit's merge semantics, not a guard clause —
@@ -156,7 +161,16 @@ describe('clone-on-write prop removal', () => {
       );
 
       eventHandler!(handle, 'topTouchEnd', {});
-      // The whole point: opacity must be GONE (reset), not stuck at 0.2 after the merge.
+      // Plain Pressable follows RN's 130ms active-duration floor, so the prop remains during the
+      // floor and must then be GONE (reset), not stuck at 0.2 after the Fabric merge.
+      expect(findByTestId(committed, TEST_ID)?.props.opacity).toBe(
+        ACTIVE_OPACITY,
+      );
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS - 1);
+      expect(findByTestId(committed, TEST_ID)?.props.opacity).toBe(
+        ACTIVE_OPACITY,
+      );
+      vi.advanceTimersByTime(1);
       expect(findByTestId(committed, TEST_ID)?.props.opacity).toBeUndefined();
     });
   });

--- a/adapters/react/src/components/pressable/index.ts
+++ b/adapters/react/src/components/pressable/index.ts
@@ -14,6 +14,7 @@
 
 import {
   createElement,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -23,11 +24,13 @@ import {
 import {
   createPressHandlers,
   createPressRuntime,
+  disposePressRuntime,
   rippleProps,
   buildPressableListeners,
   resolveDisabledAccessibilityState,
   noteHoverNoop,
   DEFAULT_DELAY_LONG_PRESS_MS,
+  DEFAULT_MIN_PRESS_DURATION_MS,
   type IPressHost,
   type IPressState,
   type IPressHandler,
@@ -36,6 +39,7 @@ import {
 } from '@symbiote-native/components';
 import { View } from '../../components';
 import type { IHostInstance } from '../../host-instance';
+import { flushExternalUpdate } from '../../host-config';
 import type {
   IAccessibilityProps,
   IAccessibilityStateValue,
@@ -89,6 +93,11 @@ export interface IPressableProps extends IAccessibilityProps, IAriaProps {
   children?: IChildrenProp;
 }
 
+interface IConfiguredPressableProps extends IPressableProps {
+  /** @internal Touchable* mirrors RN's Pressability minPressDuration: 0 override. */
+  __minPressDuration?: number;
+}
+
 function resolveStyle(
   style: IPressableStyle | undefined,
   state: IPressState,
@@ -105,7 +114,7 @@ function resolveChildren(
   return children;
 }
 
-export const Pressable: FC<IPressableProps> = props => {
+const PressableImpl: FC<IConfiguredPressableProps> = props => {
   const {
     onPress,
     onPressIn,
@@ -118,6 +127,7 @@ export const Pressable: FC<IPressableProps> = props => {
     hitSlop,
     pressRetentionOffset,
     unstable_pressDelay = 0,
+    __minPressDuration = DEFAULT_MIN_PRESS_DURATION_MS,
     android_ripple,
     android_disableSound,
     onHoverIn,
@@ -150,11 +160,21 @@ export const Pressable: FC<IPressableProps> = props => {
         return callback => view.measure(callback);
       },
       schedule: (callback, ms) => {
-        const id = setTimeout(callback, ms);
+        const id = setTimeout(() => flushExternalUpdate(callback), ms);
         return () => clearTimeout(id);
       },
+      now: Date.now,
     }),
     [],
+  );
+
+  // This renderer tears insertion effects down during host updates, so use the stable passive
+  // unmount seam to cancel delayed press-in, long-press and press-out callbacks.
+  useEffect(
+    () => () => {
+      disposePressRuntime(runtime);
+    },
+    [runtime],
   );
 
   const handlers = useMemo(
@@ -168,6 +188,7 @@ export const Pressable: FC<IPressableProps> = props => {
           onLongPress,
           delayLongPress,
           unstable_pressDelay,
+          minPressDuration: __minPressDuration,
           hitSlop,
           pressRetentionOffset,
         },
@@ -182,6 +203,7 @@ export const Pressable: FC<IPressableProps> = props => {
       onLongPress,
       delayLongPress,
       unstable_pressDelay,
+      __minPressDuration,
       hitSlop,
       pressRetentionOffset,
       runtime,
@@ -226,3 +248,8 @@ export const Pressable: FC<IPressableProps> = props => {
 
   return createElement(View, viewProps, inner);
 };
+
+export const Pressable: FC<IPressableProps> = PressableImpl;
+// Relative-only composition seam; it is deliberately absent from the adapter barrel.
+export const TouchablePressable: FC<IPressableProps> = props =>
+  createElement(PressableImpl, { ...props, __minPressDuration: 0 });

--- a/adapters/react/src/components/pressable/pressable.test.tsx
+++ b/adapters/react/src/components/pressable/pressable.test.tsx
@@ -9,18 +9,17 @@
 // shared recorder has no `measure`, so graft a configurable one onto the live slot before
 // any mount. Long-press / pressDelay timers run on vitest fake timers.
 //
-// SCOPE: `@symbiote-native/components/state/pressable.ts` (the timer/drift/suppression machine
-// createPressHandlers/createPressRuntime is called from) has NO co-located unit test of its own
-// (unlike touchable.ts, which does — core/components/src/state/touchable.test.ts). This file is
-// therefore not pure adapter-wiring coverage: it is, together with the Svelte smoke test, the
-// only place the shared press machine's actual timer/drift/suppression behavior is proven. Kept
-// here rather than split out, because the machine has no seam to drive without real touch events.
+// SCOPE: core/components/src/state/pressable.test.ts owns the timer/transition machine directly.
+// This file proves the React lifecycle bridge: responder listeners reach the real host, state
+// updates survive a re-render, the 130ms floor uses React's scheduler/clock, and unmount disposes
+// pending work.
 //
 // No Negative group: nothing here has a throwing path. "disabled" suppresses a press silently
 // (a Positive contract — completes without error, callback just never fires), it never rejects.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount, Pressable, Button } from '@symbiote-native/react';
+import { DEFAULT_MIN_PRESS_DURATION_MS } from '@symbiote-native/components';
 import { installFabric, type IFakeNode } from '@symbiote-native/test-utils';
 
 const ROOT_TAG = 110;
@@ -283,13 +282,17 @@ describe('React Pressable on the engine', () => {
     fireAt(handle, TOUCH_MOVE, 108, 106); // hypot(8,6) = 10 < 30 -> retained
     fireAt(handle, TOUCH_END, 108, 106);
     expect(presses).toBe(1);
+    expect(pressOuts).toBe(0);
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
     expect(pressOuts).toBe(1);
 
-    // (b) large drift past the region -> tap suppressed, early pressOut fired.
+    // (b) large drift past the region -> tap suppressed; pressOut keeps RN's active floor.
     presses = 0;
     pressOuts = 0;
     fireAt(handle, TOUCH_START, 100, 100);
     fireAt(handle, TOUCH_MOVE, 200, 100); // 100 > 30 -> drifted out
+    expect(pressOuts).toBe(0);
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
     expect(pressOuts).toBe(1);
     fireAt(handle, TOUCH_END, 200, 100);
     expect(presses).toBe(0);
@@ -335,6 +338,49 @@ describe('React Pressable on the engine', () => {
     expect(presses).toBe(1);
   });
 
+  it('holds onPressOut for RN’s 130ms minimum active duration', () => {
+    let pressOuts = 0;
+    mount(
+      ROOT_TAG,
+      <Pressable
+        onPress={() => {}}
+        onPressOut={() => {
+          pressOuts++;
+        }}
+      />,
+    );
+    const handle = responderHandle();
+
+    fire(handle, TOUCH_START);
+    fire(handle, TOUCH_END);
+    expect(pressOuts).toBe(0);
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS - 1);
+    expect(pressOuts).toBe(0);
+    vi.advanceTimersByTime(1);
+    expect(pressOuts).toBe(1);
+  });
+
+  it('cancels a pending unstable_pressDelay timer on unmount', () => {
+    let pressIns = 0;
+    mount(
+      ROOT_TAG,
+      <Pressable
+        unstable_pressDelay={120}
+        onPressIn={() => {
+          pressIns++;
+        }}
+      />,
+    );
+
+    const handle = responderHandle();
+    fire(handle, TOUCH_START);
+    unmount(ROOT_TAG);
+    vi.advanceTimersByTime(120);
+    expect(pressIns).toBe(0);
+    // Clear the test harness's process-global responder after proving teardown cancelled the timer.
+    fire(handle, 'topTouchCancel');
+  });
+
   // why: pressRetentionOffset can be set per-edge (not just a uniform radius) — the drift test
   // must measure against the real per-edge frame, not a symmetric approximation, or an
   // asymmetric layout (e.g. a wide short button) would retain/drop on the wrong side.
@@ -361,12 +407,15 @@ describe('React Pressable on the engine', () => {
     fireAt(handle, TOUCH_MOVE, 130, 20);
     fireAt(handle, TOUCH_END, 130, 20);
     expect(presses).toBe(1);
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
 
-    // (b) y=80 is past the bottom edge (40+30=70) -> drifted out, early pressOut, tap dropped.
+    // (b) y=80 is past the bottom edge (40+30=70) -> drifted out, tap dropped.
     presses = 0;
     pressOuts = 0;
     fireAt(handle, TOUCH_START, 50, 20);
     fireAt(handle, TOUCH_MOVE, 50, 80);
+    expect(pressOuts).toBe(0);
+    vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
     expect(pressOuts).toBe(1);
     fireAt(handle, TOUCH_END, 50, 80);
     expect(presses).toBe(0);

--- a/adapters/react/src/components/touchable-native-feedback/index.ts
+++ b/adapters/react/src/components/touchable-native-feedback/index.ts
@@ -20,7 +20,10 @@ import {
   type IRippleBackground,
 } from '@symbiote-native/components';
 import { View } from '../../components';
-import { Pressable, type IPressableProps } from '../pressable';
+import {
+  TouchablePressable as Pressable,
+  type IPressableProps,
+} from '../pressable';
 
 export type {
   INativeFeedbackBackground,

--- a/adapters/react/src/components/touchable/index.ts
+++ b/adapters/react/src/components/touchable/index.ts
@@ -36,7 +36,10 @@ import {
   type IPressTimingProps,
 } from '@symbiote-native/components';
 import type { ISymbioteEvent } from '@symbiote-native/engine';
-import { Pressable, type IPressableProps } from '../pressable';
+import {
+  TouchablePressable as Pressable,
+  type IPressableProps,
+} from '../pressable';
 import { Animated } from '../../modules/animated';
 import type { IStyleProp, IViewStyle } from '../../utils/styles';
 

--- a/adapters/react/src/host-config.ts
+++ b/adapters/react/src/host-config.ts
@@ -81,8 +81,9 @@ function isSurfaceContainer(
 
 let currentUpdatePriority = NoEventPriority;
 
-// Run an externally-triggered update (a native event) at discrete priority so it
-// lands on the sync lane and flushSyncWork paints it immediately.
+// Run the callback at discrete priority. Native events and component-owned timers both enter
+// React outside its render loop; callers pair this with flushExternalUpdate when the result must
+// paint synchronously.
 export function withDiscretePriority(run: () => void): void {
   const previous = currentUpdatePriority;
   currentUpdatePriority = DiscreteEventPriority;
@@ -226,5 +227,14 @@ const reconciler = createReconciler<
   suspendInstance: () => {},
   waitForCommitToBeReady: () => null,
 });
+
+// Native-event and timer callbacks both update React from outside the reconciler. Put the update
+// on the discrete lane and synchronously commit it; otherwise a delayed Pressable transition can
+// mutate state but remain visually stale until some unrelated later event flushes React work.
+export function flushExternalUpdate(run: () => void): void {
+  withDiscretePriority(run);
+  // @ts-expect-error flushSyncWork exists at runtime in react-reconciler 0.33
+  reconciler.flushSyncWork();
+}
 
 export default reconciler;

--- a/adapters/react/src/render.ts
+++ b/adapters/react/src/render.ts
@@ -12,7 +12,7 @@ import {
   type IRootTag,
   type SymbioteSurface,
 } from '@symbiote-native/engine';
-import reconciler, { withDiscretePriority } from './host-config';
+import reconciler, { flushExternalUpdate } from './host-config';
 import { LegacyRoot } from './reconciler-constants';
 
 const noop = (): void => {};
@@ -71,10 +71,8 @@ const onRecoverableError = errorReporter('react render (recovered)');
 // to compare against Vue/Angular's microtask-coalesced requestCommit(). Kept
 // behind DEBUG per <keep_logs_gate_behind_DEBUG>, never removed.
 setEventDispatcher(run => {
-  withDiscretePriority(run);
   dlog('react event-dispatch: forced flushSyncWork');
-  // @ts-expect-error flushSyncWork exists at runtime in react-reconciler 0.33
-  reconciler.flushSyncWork();
+  flushExternalUpdate(run);
 });
 
 // The reconciler container per surface, so a surface can be torn down (unmount)

--- a/adapters/solid/src/components/pressable-render-prop.test.tsx
+++ b/adapters/solid/src/components/pressable-render-prop.test.tsx
@@ -21,6 +21,7 @@
 
 import { createSignal } from 'solid-js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_MIN_PRESS_DURATION_MS } from '@symbiote-native/components';
 import { installFabric, type IFakeNode } from '@symbiote-native/test-utils';
 import { mount, unmount } from '../render';
 import { ActivityIndicator } from './activity-indicator';
@@ -132,8 +133,13 @@ describe('Pressable with a function child, across repeated press cycles', () => 
     );
 
     fabric.fireEvent(handle, TOUCH_END);
-    await flush();
-    expect(committedLabel(), 'the leaf must go back').toBe('up');
+    await new Promise(resolve =>
+      setTimeout(resolve, DEFAULT_MIN_PRESS_DURATION_MS + 10),
+    );
+    expect(
+      committedLabel(),
+      'the leaf must go back after RN’s active floor',
+    ).toBe('up');
     expect(fabric.counts.createNode, 'release rebuilt the child subtree').toBe(
       createdAtMount,
     );
@@ -249,8 +255,10 @@ describe('Pressable with a function child, across repeated press cycles', () => 
     expect(committedLabel(), 'while held').toBe('down');
 
     fabric.fireEvent(handle, TOUCH_END);
-    await flush();
-    expect(committedLabel(), 'after release').toBe('up');
+    await new Promise(resolve =>
+      setTimeout(resolve, DEFAULT_MIN_PRESS_DURATION_MS + 10),
+    );
+    expect(committedLabel(), 'after the active-duration floor').toBe('up');
   });
 
   // why: the last device-only difference the tests above cannot reach. Real touches carry

--- a/adapters/solid/src/components/pressable.test.tsx
+++ b/adapters/solid/src/components/pressable.test.tsx
@@ -24,6 +24,7 @@
 
 import { createSignal } from 'solid-js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_MIN_PRESS_DURATION_MS } from '@symbiote-native/components';
 import { installFabric, type IFakeNode } from '@symbiote-native/test-utils';
 import { mount, unmount } from '../render';
 import { Pressable } from './pressable';
@@ -181,8 +182,10 @@ describe('Solid Pressable on the engine', () => {
       expect(presses).toBe(0);
 
       fire(handle, TOUCH_END);
-      expect(pressOuts).toBe(1);
+      expect(pressOuts).toBe(0);
       expect(presses).toBe(1);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
+      expect(pressOuts).toBe(1);
     });
 
     // why: RN's disabled Pressable must not claim the responder or fire feedback at all, and must
@@ -309,12 +312,16 @@ describe('Solid Pressable on the engine', () => {
       fireAt(handle, TOUCH_MOVE, 108, 106); // hypot(8,6) = 10 < 30 -> retained
       fireAt(handle, TOUCH_END, 108, 106);
       expect(presses).toBe(1);
+      expect(pressOuts).toBe(0);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
       expect(pressOuts).toBe(1);
 
       presses = 0;
       pressOuts = 0;
       fireAt(handle, TOUCH_START, 100, 100);
       fireAt(handle, TOUCH_MOVE, 200, 100); // 100 > 30 -> drifted out
+      expect(pressOuts).toBe(0);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
       expect(pressOuts).toBe(1);
       fireAt(handle, TOUCH_END, 200, 100);
       expect(presses).toBe(0);
@@ -348,12 +355,15 @@ describe('Solid Pressable on the engine', () => {
       fireAt(handle, TOUCH_MOVE, 130, 20);
       fireAt(handle, TOUCH_END, 130, 20);
       expect(presses).toBe(1);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
 
-      // (b) y=80 is past the bottom edge (40+30=70) -> drifted out, early pressOut, tap dropped.
+      // (b) y=80 is past the bottom edge (40+30=70) -> drifted out, tap dropped.
       presses = 0;
       pressOuts = 0;
       fireAt(handle, TOUCH_START, 50, 20);
       fireAt(handle, TOUCH_MOVE, 50, 80);
+      expect(pressOuts).toBe(0);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
       expect(pressOuts).toBe(1);
       fireAt(handle, TOUCH_END, 50, 80);
       expect(presses).toBe(0);
@@ -395,6 +405,29 @@ describe('Solid Pressable on the engine', () => {
       fireAt(handle, TOUCH_END, 50, 50); // released before advancing the timer
       expect(pressIns).toBe(1);
       expect(presses).toBe(1);
+    });
+
+    it('cancels a pending unstable_pressDelay timer on unmount', async () => {
+      let pressIns = 0;
+      mount(ROOT_TAG, () => (
+        <Pressable
+          testID={TARGET}
+          unstable_pressDelay={PRESS_DELAY_MS}
+          onPressIn={() => {
+            pressIns++;
+          }}
+        />
+      ));
+      await flush();
+
+      const handle = responderHandle();
+      fire(handle, TOUCH_START);
+      unmount(ROOT_TAG);
+      vi.advanceTimersByTime(PRESS_DELAY_MS);
+      expect(pressIns).toBe(0);
+      // The adapter is already disposed; clear the test harness's process-global responder only
+      // after the assertion, so cancellation cannot make the timer test falsely green.
+      fire(handle, 'topTouchCancel');
     });
 
     // why: onPressMove is a distinct RN callback from the retention drift bookkeeping — it must
@@ -598,6 +631,7 @@ describe('Solid Pressable on the engine', () => {
       expect(findCommitted(n => n.props.testID === 'pressed')).toBeDefined();
 
       fire(handle, TOUCH_END);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
       await flush();
       expect(findCommitted(n => n.props.testID === 'idle')).toBeDefined();
     });
@@ -680,6 +714,7 @@ describe('Solid Pressable on the engine', () => {
       );
 
       fire(handle, TOUCH_END);
+      vi.advanceTimersByTime(DEFAULT_MIN_PRESS_DURATION_MS);
       await flush();
       expect(committedTargetProps().opacity).toBe(1);
     });

--- a/adapters/solid/src/components/pressable.tsx
+++ b/adapters/solid/src/components/pressable.tsx
@@ -26,6 +26,7 @@
 import {
   createEffect,
   createMemo,
+  onCleanup,
   createSignal,
   splitProps,
   untrack,
@@ -36,10 +37,12 @@ import {
   buildPressableListeners,
   createPressHandlers,
   createPressRuntime,
+  disposePressRuntime,
   noteHoverNoop,
   resolveDisabledAccessibilityState,
   rippleProps,
   DEFAULT_DELAY_LONG_PRESS_MS,
+  DEFAULT_MIN_PRESS_DURATION_MS,
   type IAccessibilityProps,
   type IAriaProps,
   type IPressHandler,
@@ -157,7 +160,10 @@ const HANDLED_PROPS = [
 // `hitSlop` is deliberately NOT in that list: the machine reads it for the retention test AND the
 // host needs it to enlarge the touch target, so it forwards through `rest` untouched.
 
-export function Pressable(props: IPressableProps): JSX.Element {
+function PressableImpl(
+  props: IPressableProps,
+  minPressDuration: number,
+): JSX.Element {
   const [local, rest] = splitProps(props, HANDLED_PROPS);
 
   const [pressed, setPressed] = createSignal(false);
@@ -193,7 +199,12 @@ export function Pressable(props: IPressableProps): JSX.Element {
         clearTimeout(id);
       };
     },
+    now: Date.now,
   };
+
+  onCleanup(() => {
+    disposePressRuntime(runtime);
+  });
 
   // Rebuilt when the caller's config changes (the closures capture live values); the runtime
   // persists across rebuilds, so an in-flight timer or drift flag survives one. Deliberately does
@@ -208,6 +219,7 @@ export function Pressable(props: IPressableProps): JSX.Element {
         onLongPress: local.onLongPress,
         delayLongPress: local.delayLongPress ?? DEFAULT_DELAY_LONG_PRESS_MS,
         unstable_pressDelay: local.unstable_pressDelay ?? 0,
+        minPressDuration,
         hitSlop: rest.hitSlop,
         pressRetentionOffset: local.pressRetentionOffset,
       },
@@ -307,4 +319,13 @@ export function Pressable(props: IPressableProps): JSX.Element {
       {renderContent()}
     </View>
   );
+}
+
+export function Pressable(props: IPressableProps): JSX.Element {
+  return PressableImpl(props, DEFAULT_MIN_PRESS_DURATION_MS);
+}
+
+// Relative-only composition seam; the public component barrel exports Pressable, never this.
+export function TouchablePressable(props: IPressableProps): JSX.Element {
+  return PressableImpl(props, 0);
 }

--- a/adapters/solid/src/components/touchable-native-feedback/index.tsx
+++ b/adapters/solid/src/components/touchable-native-feedback/index.tsx
@@ -31,7 +31,10 @@ import {
 } from '@symbiote-native/components';
 import { dlog } from '@symbiote-native/engine';
 import { withStableKeys } from '../../utils/stable-keys';
-import { Pressable, type IPressableProps } from '../pressable';
+import {
+  TouchablePressable as Pressable,
+  type IPressableProps,
+} from '../pressable';
 
 export type {
   INativeFeedbackBackground,

--- a/adapters/solid/src/components/touchable/index.tsx
+++ b/adapters/solid/src/components/touchable/index.tsx
@@ -47,7 +47,10 @@ import {
   type IViewStyle,
 } from '@symbiote-native/engine';
 import { Animated } from '../../modules/animated';
-import { Pressable, type IPressableProps } from '../pressable';
+import {
+  TouchablePressable as Pressable,
+  type IPressableProps,
+} from '../pressable';
 
 // Declared here, not imported from @symbiote-native/components and never from another adapter:
 // `children` is a framework value, which is exactly the test

--- a/adapters/svelte/src/components/pressable/index.svelte
+++ b/adapters/svelte/src/components/pressable/index.svelte
@@ -22,15 +22,18 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import {
     createPressHandlers,
     createPressRuntime,
+    disposePressRuntime,
     rippleProps,
     buildPressableListeners,
     resolveDisabledAccessibilityState,
     resolveAccessibilityProps,
     noteHoverNoop,
     DEFAULT_DELAY_LONG_PRESS_MS,
+    DEFAULT_MIN_PRESS_DURATION_MS,
     type IPressHost,
     type IPressState,
   } from '@symbiote-native/components';
@@ -50,6 +53,7 @@
     hitSlop,
     pressRetentionOffset,
     unstable_pressDelay = 0,
+    __minPressDuration = DEFAULT_MIN_PRESS_DURATION_MS,
     android_ripple,
     android_disableSound,
     onHoverIn,
@@ -61,7 +65,10 @@
     class: className,
     children,
     ...rest
-  }: IPressableProps = $props();
+  }: IPressableProps & {
+    /** @internal Touchable* mirrors RN's Pressability minPressDuration: 0 override. */
+    __minPressDuration?: number;
+  } = $props();
 
   let pressed = $state(false);
   // Plain setup-scope object, never `$state`: mutated by the machine on every event, never
@@ -85,7 +92,12 @@
       const id = setTimeout(callback, ms);
       return () => clearTimeout(id);
     },
+    now: Date.now,
   };
+
+  onDestroy(() => {
+    disposePressRuntime(runtime);
+  });
 
   $effect(() => {
     noteHoverNoop(onHoverIn, onHoverOut);
@@ -107,6 +119,7 @@
         onLongPress,
         delayLongPress,
         unstable_pressDelay,
+        minPressDuration: __minPressDuration,
         hitSlop,
         pressRetentionOffset,
       },

--- a/adapters/svelte/src/components/pressable/pressable.smoke.test.ts
+++ b/adapters/svelte/src/components/pressable/pressable.smoke.test.ts
@@ -104,9 +104,9 @@ async function loadMountable(): Promise<Component> {
   compileToFile(
     `<script>
        import Pressable from './.smoke-compiled-pressable.mjs';
-       let { onPress, onPressIn, onPressOut } = $props();
+       let { onPress, onPressIn, onPressOut, unstable_pressDelay } = $props();
      </script>
-     <Pressable {onPress} {onPressIn} {onPressOut}>
+     <Pressable {onPress} {onPressIn} {onPressOut} {unstable_pressDelay}>
        {#snippet children(state)}
          <symbiote-view p={{ testID: state.pressed ? 'pressed' : 'idle' }} />
        {/snippet}
@@ -214,7 +214,34 @@ describe('Pressable (real compiled index.svelte)', () => {
 
       fabric.fireEvent(handle, 'topTouchEnd');
       await waitUntil(() => presses === 1, 'onPress after topTouchEnd');
-      expect(pressOuts).toBe(1);
+      expect(pressOuts).toBe(0);
+      await waitUntil(
+        () => pressOuts === 1,
+        'onPressOut after the active-duration floor',
+      );
+    });
+
+    it('cancels a pending unstable_pressDelay timer on destroy', async () => {
+      let pressIns = 0;
+      const Parent = await loadMountable();
+      mount(ROOT_TAG, Parent, {
+        unstable_pressDelay: 30,
+        onPress: () => {},
+        onPressIn: () => {
+          pressIns++;
+        },
+        onPressOut: () => {},
+      });
+      await tick();
+      await tick();
+
+      const handle = responderHandle();
+      fabric.fireEvent(handle, 'topTouchStart');
+      unmount(ROOT_TAG);
+      await new Promise(resolve => setTimeout(resolve, 40));
+      expect(pressIns).toBe(0);
+      // Clear the process-global responder only after proving onDestroy cancelled the timer.
+      fabric.fireEvent(handle, 'topTouchCancel');
     });
 
     // why: proves the `IPressHost.setPressed` bridge actually reaches the parameterized

--- a/adapters/svelte/src/components/touchable-highlight/index.svelte
+++ b/adapters/svelte/src/components/touchable-highlight/index.svelte
@@ -126,6 +126,7 @@
 </script>
 
 <Pressable
+  __minPressDuration={0}
   {...rest}
   style={containerStyle}
   onPress={handlePress}

--- a/adapters/svelte/src/components/touchable-native-feedback/touchable-native-feedback.svelte
+++ b/adapters/svelte/src/components/touchable-native-feedback/touchable-native-feedback.svelte
@@ -40,7 +40,7 @@
   const nativeProps = $derived(backgroundProps(resolved, useForeground));
 </script>
 
-<Pressable {...rest}>
+<Pressable __minPressDuration={0} {...rest}>
   {#snippet children()}
     <symbiote-view p={nativeProps}>
       {@render content?.()}

--- a/adapters/svelte/src/components/touchable-opacity/index.svelte
+++ b/adapters/svelte/src/components/touchable-opacity/index.svelte
@@ -168,6 +168,7 @@
 </script>
 
 <Pressable
+  __minPressDuration={0}
   {...rest}
   onPressIn={handlers.handlePressIn}
   onPressOut={handlers.handlePressOut}

--- a/adapters/svelte/src/components/touchable-without-feedback/index.svelte
+++ b/adapters/svelte/src/components/touchable-without-feedback/index.svelte
@@ -64,6 +64,7 @@
 </script>
 
 <Pressable
+  __minPressDuration={0}
   {...rest}
   onPressIn={handlers.handlePressIn}
   onPressOut={handlers.handlePressOut}

--- a/adapters/vue/src/components/pressable.test.ts
+++ b/adapters/vue/src/components/pressable.test.ts
@@ -1,0 +1,61 @@
+// Vue lifecycle coverage for the shared Pressable machine. Core tests own timing and transition
+// semantics; this proves Vue's setup-scope runtime is disposed by onUnmounted rather than letting a
+// delayed callback write into a dead ref/emitter.
+import { defineComponent, h } from '@vue/runtime-core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, Pressable, unmount } from '@symbiote-native/vue';
+import { installFabric } from '@symbiote-native/test-utils';
+
+const ROOT_TAG = 518;
+const PRESS_DELAY_MS = 30;
+const fabric = installFabric();
+const tick = (): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  fabric.reset();
+});
+afterEach(() => unmount(ROOT_TAG));
+
+function responderHandle(): unknown {
+  const node = fabric.find(candidate => {
+    if (candidate.viewName !== 'RCTView') return false;
+    const handle = candidate.instanceHandle;
+    return (
+      typeof handle === 'object' &&
+      handle !== null &&
+      Reflect.get(handle, 'listeners') instanceof Map &&
+      Reflect.get(handle, 'listeners').has('press')
+    );
+  });
+  if (node === undefined)
+    throw new Error('no Vue Pressable responder was created');
+  return node.instanceHandle;
+}
+
+describe('Vue Pressable lifecycle', () => {
+  it('cancels a pending unstable_pressDelay timer on unmount', async () => {
+    let pressIns = 0;
+    mount(
+      ROOT_TAG,
+      defineComponent({
+        setup: () => () =>
+          h(Pressable, {
+            unstable_pressDelay: PRESS_DELAY_MS,
+            onPressIn: () => {
+              pressIns++;
+            },
+          }),
+      }),
+    );
+    await tick();
+
+    const handle = responderHandle();
+    fabric.fireEvent(handle, 'topTouchStart');
+    unmount(ROOT_TAG);
+    await new Promise(resolve => setTimeout(resolve, PRESS_DELAY_MS + 10));
+    expect(pressIns).toBe(0);
+    // Clear the process-global responder only after proving onUnmounted cancelled the timer.
+    fabric.fireEvent(handle, 'topTouchCancel');
+  });
+});

--- a/adapters/vue/src/components/pressable.ts
+++ b/adapters/vue/src/components/pressable.ts
@@ -15,6 +15,7 @@
 import {
   defineComponent,
   h,
+  onUnmounted,
   ref,
   shallowRef,
   type EmitFn,
@@ -23,12 +24,14 @@ import {
 import {
   createPressHandlers,
   createPressRuntime,
+  disposePressRuntime,
   rippleProps,
   buildPressableListeners,
   resolveDisabledAccessibilityState,
   noteHoverNoop,
   resolveAccessibilityProps,
   DEFAULT_DELAY_LONG_PRESS_MS,
+  DEFAULT_MIN_PRESS_DURATION_MS,
   type IPressHost,
   type IPressState,
   type IRectOffset,
@@ -194,6 +197,7 @@ const HANDLED_ATTRS = [
   'cancelable',
   'pressRetentionOffset',
   'unstable_pressDelay',
+  '__minPressDuration',
   'android_ripple',
   'android_disableSound',
   'onHoverIn',
@@ -243,7 +247,12 @@ export const Pressable = defineComponent(
         const id = setTimeout(callback, ms);
         return () => clearTimeout(id);
       },
+      now: Date.now,
     };
+
+    onUnmounted(() => {
+      disposePressRuntime(runtime);
+    });
 
     return () => {
       const attrs = normalizeVueAttrs(rawAttrs);
@@ -262,6 +271,10 @@ export const Pressable = defineComponent(
           DEFAULT_DELAY_LONG_PRESS_MS,
         ),
         unstable_pressDelay: numberOr(attrs.unstable_pressDelay, 0),
+        minPressDuration: numberOr(
+          attrs.__minPressDuration,
+          DEFAULT_MIN_PRESS_DURATION_MS,
+        ),
         hitSlop: asRectOffset(attrs.hitSlop),
         pressRetentionOffset: asRectOffset(attrs.pressRetentionOffset),
       };

--- a/adapters/vue/src/components/touchable-native-feedback.ts
+++ b/adapters/vue/src/components/touchable-native-feedback.ts
@@ -102,7 +102,11 @@ const TouchableNativeFeedbackImpl = defineComponent<
       const feedback = h(View, nativeProps, () => children);
       return h(
         Pressable,
-        { ...forwardAttrs(attrs), ...emitPressableEvents(emit) },
+        {
+          ...forwardAttrs(attrs),
+          ...emitPressableEvents(emit),
+          __minPressDuration: 0,
+        },
         { default: () => [feedback] },
       );
     };

--- a/adapters/vue/src/components/touchable.ts
+++ b/adapters/vue/src/components/touchable.ts
@@ -206,6 +206,7 @@ export const TouchableOpacity = defineComponent<
         },
       );
       const pressableProps: Record<string, unknown> = {
+        __minPressDuration: 0,
         ...forwardExcept(attrs, TOUCHABLE_OPACITY_HANDLED),
         ...emitPressableEvents(emit),
         onPressIn: handlePressIn,
@@ -337,6 +338,7 @@ export const TouchableHighlight = defineComponent<
             : [attrs.style, extra.underlay, extra.child];
 
       const pressableProps: Record<string, unknown> = {
+        __minPressDuration: 0,
         ...forwardExcept(attrs, TOUCHABLE_HIGHLIGHT_HANDLED),
         ...emitPressableEvents(emit),
         style: containerStyle,
@@ -405,6 +407,7 @@ export const TouchableWithoutFeedback = defineComponent<
         },
       );
       const pressableProps: Record<string, unknown> = {
+        __minPressDuration: 0,
         ...forwardExcept(attrs, TOUCHABLE_WITHOUT_FEEDBACK_HANDLED),
         ...emitPressableEvents(emit),
         onPressIn: handlePressIn,

--- a/core/components/src/index.ts
+++ b/core/components/src/index.ts
@@ -201,6 +201,7 @@ export type {
 export {
   createPressHandlers,
   createPressRuntime,
+  disposePressRuntime,
   normalizeRect,
   maxEdge,
   isTouchWithinRegion,
@@ -208,6 +209,7 @@ export {
   computeRegion,
   rippleProps,
   DEFAULT_DELAY_LONG_PRESS_MS,
+  DEFAULT_MIN_PRESS_DURATION_MS,
   DEFAULT_PRESS_RECT_OFFSETS,
 } from './state/pressable';
 export type {

--- a/core/components/src/state/pressable.test.ts
+++ b/core/components/src/state/pressable.test.ts
@@ -1,0 +1,257 @@
+// Deterministic unit tests for the shared Pressable state machine. Framework tests prove that each
+// adapter wires this machine to its own lifecycle; this file owns the timing/transition contract
+// itself: delayed activation, retention drift/re-entry, RN's 130ms active-duration floor, and
+// teardown of every timer class.
+import { createElement, type ISymbioteEvent } from '@symbiote-native/engine';
+import { describe, expect, it } from 'vitest';
+import {
+  createPressHandlers,
+  createPressRuntime,
+  disposePressRuntime,
+  DEFAULT_MIN_PRESS_DURATION_MS,
+  type IPressHost,
+  type IPressMachineConfig,
+} from './pressable';
+
+interface IScheduled {
+  due: number;
+  callback: () => void;
+  cancelled: boolean;
+}
+
+function makeClock(): {
+  schedule: IPressHost['schedule'];
+  now: () => number;
+  advance: (ms: number) => void;
+  pending: () => number;
+} {
+  let now = 0;
+  const scheduled: IScheduled[] = [];
+  return {
+    schedule(callback, ms) {
+      const entry: IScheduled = { due: now + ms, callback, cancelled: false };
+      scheduled.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    },
+    now: () => now,
+    advance(ms) {
+      const target = now + ms;
+      for (;;) {
+        const due = scheduled
+          .filter(entry => !entry.cancelled && entry.due <= target)
+          .sort((a, b) => a.due - b.due)[0];
+        if (due === undefined) break;
+        now = due.due;
+        due.cancelled = true;
+        due.callback();
+      }
+      now = target;
+    },
+    pending: () => scheduled.filter(entry => !entry.cancelled).length,
+  };
+}
+
+function eventAt(x = 0, y = 0): ISymbioteEvent {
+  const target = createElement('RCTView');
+  return {
+    type: 'press',
+    target,
+    currentTarget: target,
+    nativeEvent: { pageX: x, pageY: y },
+    stopPropagation: () => {},
+  };
+}
+
+function makeHarness(overrides: Partial<IPressMachineConfig> = {}) {
+  const clock = makeClock();
+  const log: string[] = [];
+  const runtime = createPressRuntime();
+  const config: IPressMachineConfig = {
+    delayLongPress: 500,
+    unstable_pressDelay: 0,
+    hitSlop: 0,
+    pressRetentionOffset: 30,
+    onPress: () => log.push('press'),
+    onPressIn: () => log.push('in'),
+    onPressOut: () => log.push('out'),
+    onLongPress: () => log.push('long'),
+    ...overrides,
+  };
+  const host: IPressHost = {
+    setPressed: pressed => log.push(pressed ? 'pressed:true' : 'pressed:false'),
+    getMeasureFn: () => undefined,
+    schedule: clock.schedule,
+    now: clock.now,
+  };
+  return {
+    clock,
+    log,
+    runtime,
+    handlers: createPressHandlers(config, runtime, host),
+  };
+}
+
+describe('Pressable delayed activation and retention', () => {
+  it('never activates or emits pressOut when the touch leaves before the delay and stays out', () => {
+    const { clock, handlers, log } = makeHarness({ unstable_pressDelay: 120 });
+
+    handlers.handlePressIn(eventAt(0, 0));
+    handlers.handleResponderMove(eventAt(100, 0));
+    clock.advance(120);
+    handlers.handlePress(eventAt(100, 0));
+    handlers.handlePressOut(eventAt(100, 0));
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS);
+
+    expect(log).toEqual([]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('activates once the delay elapsed and the touch returns inside', () => {
+    const { clock, handlers, log } = makeHarness({ unstable_pressDelay: 120 });
+
+    handlers.handlePressIn(eventAt(0, 0));
+    handlers.handleResponderMove(eventAt(100, 0));
+    clock.advance(120);
+    expect(log).toEqual([]);
+
+    handlers.handleResponderMove(eventAt(10, 0));
+    expect(log).toEqual(['pressed:true', 'in']);
+  });
+
+  it('cancels a deferred pressOut when the active touch returns inside', () => {
+    const { clock, handlers, log } = makeHarness();
+
+    handlers.handlePressIn(eventAt(0, 0));
+    clock.advance(10);
+    handlers.handleResponderMove(eventAt(100, 0));
+    clock.advance(20);
+    handlers.handleResponderMove(eventAt(10, 0));
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS);
+
+    expect(log).toEqual(['pressed:true', 'in', 'pressed:true', 'in']);
+  });
+});
+
+describe('Pressable release timing', () => {
+  it('flushes an early in-bounds release, fires press, then holds pressOut for 130ms', () => {
+    const { clock, handlers, log } = makeHarness({ unstable_pressDelay: 120 });
+
+    handlers.handlePressIn(eventAt());
+    handlers.handlePress(eventAt());
+    handlers.handlePressOut(eventAt());
+    expect(log).toEqual(['pressed:true', 'in', 'press']);
+
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS - 1);
+    expect(log).toEqual(['pressed:true', 'in', 'press']);
+    clock.advance(1);
+    expect(log).toEqual([
+      'pressed:true',
+      'in',
+      'press',
+      'pressed:false',
+      'out',
+    ]);
+  });
+
+  it('supports Touchable’s internal zero-duration Pressability override', () => {
+    const { handlers, log, clock } = makeHarness({ minPressDuration: 0 });
+
+    handlers.handlePressIn(eventAt());
+    handlers.handlePress(eventAt());
+    handlers.handlePressOut(eventAt());
+
+    expect(log).toEqual([
+      'pressed:true',
+      'in',
+      'press',
+      'pressed:false',
+      'out',
+    ]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('deactivates immediately once the press was already active for 130ms', () => {
+    const { clock, handlers, log } = makeHarness();
+
+    handlers.handlePressIn(eventAt());
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS);
+    handlers.handlePress(eventAt());
+    handlers.handlePressOut(eventAt());
+
+    expect(log).toEqual([
+      'pressed:true',
+      'in',
+      'press',
+      'pressed:false',
+      'out',
+    ]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('does not synthesize activation for a cancellation before the press delay', () => {
+    const { clock, handlers, log } = makeHarness({ unstable_pressDelay: 120 });
+
+    handlers.handlePressIn(eventAt());
+    handlers.handlePressOut(eventAt());
+    clock.advance(500);
+
+    expect(log).toEqual([]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('emits one deferred pressOut when a live press drifts out, never a duplicate on release', () => {
+    const { clock, handlers, log } = makeHarness();
+
+    handlers.handlePressIn(eventAt(0, 0));
+    clock.advance(20);
+    handlers.handleResponderMove(eventAt(100, 0));
+    handlers.handlePress(eventAt(100, 0));
+    handlers.handlePressOut(eventAt(100, 0));
+    expect(log).toEqual(['pressed:true', 'in']);
+
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS - 20);
+    expect(log).toEqual(['pressed:true', 'in', 'pressed:false', 'out']);
+    expect(clock.pending()).toBe(0);
+  });
+});
+
+describe('disposePressRuntime', () => {
+  it('cancels a pending press delay and prevents its callback after teardown', () => {
+    const { clock, handlers, log, runtime } = makeHarness({
+      unstable_pressDelay: 120,
+    });
+
+    handlers.handlePressIn(eventAt());
+    disposePressRuntime(runtime);
+    clock.advance(120);
+
+    expect(log).toEqual([]);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('cancels a pending long press after activation', () => {
+    const { clock, handlers, log, runtime } = makeHarness();
+
+    handlers.handlePressIn(eventAt());
+    disposePressRuntime(runtime);
+    clock.advance(500);
+
+    expect(log).toEqual(['pressed:true', 'in']);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it('cancels a deferred pressOut and never writes into an unmounted adapter', () => {
+    const { clock, handlers, log, runtime } = makeHarness();
+
+    handlers.handlePressIn(eventAt());
+    handlers.handlePress(eventAt());
+    handlers.handlePressOut(eventAt());
+    disposePressRuntime(runtime);
+    clock.advance(DEFAULT_MIN_PRESS_DURATION_MS);
+
+    expect(log).toEqual(['pressed:true', 'in', 'press']);
+    expect(clock.pending()).toBe(0);
+  });
+});

--- a/core/components/src/state/pressable.ts
+++ b/core/components/src/state/pressable.ts
@@ -13,6 +13,8 @@
 import { dlog, Platform, type ISymbioteEvent } from '@symbiote-native/engine';
 
 export const DEFAULT_DELAY_LONG_PRESS_MS = 500;
+// Pressability's default active-visual floor for a plain Pressable. Touchable* overrides this to 0.
+export const DEFAULT_MIN_PRESS_DURATION_MS = 130;
 // RN's default extra slop kept around a press once it is active, before a drift fires pressOut.
 // The PressRect extension (Pressability.js DEFAULT_PRESS_RECT_OFFSETS). Per-edge, deeper bottom.
 export const DEFAULT_PRESS_RECT_OFFSETS = {
@@ -159,27 +161,26 @@ export function rippleProps(
 
 // ---- the press state machine ------------------------------------------------------------------
 
-// The mutable runtime the adapter holds across renders (React: a ref; Vue: setup scope). Holds
-// the in-flight timers, the suppression flags, and the measured region: exactly the React
-// adapter's refs, now in one object so the shared handlers can mutate them.
+// The mutable runtime the adapter holds across renders (React: a ref; Vue: setup scope). It owns
+// every in-flight timer and transition bit so the framework lifecycle has one disposal seam.
 export interface IPressRuntime {
-  // Cancels the in-flight long-press timer (between pressIn and pressOut/press), or undefined when
-  // none is armed. A canceller (not a raw handle) so the timer SCHEDULING (setTimeout/clear-
-  // Timeout) stays in the adapter (core/components has no DOM/Node timer globals).
   longPressCancel: (() => void) | undefined;
-  // True once the long-press timer fired, until the next pressIn rearms. RN skips onPress when a
-  // long press fired (Pressability isPressCanceledByLongPress).
   longPressFired: boolean;
-  // Cancels the in-flight unstable_pressDelay timer; the activation runs inside it.
   pressDelayCancel: (() => void) | undefined;
-  // Page coordinate the active press started at: the radius-fallback origin (headless only).
+  pressOutCancel: (() => void) | undefined;
   pressOrigin: { x: number; y: number } | undefined;
-  // True once a drift past hitSlop+retention deactivated the press; suppresses the tap on release
-  // until the finger returns inside the region.
   driftedOut: boolean;
-  // The measured frame from the latest grant; undefined until measure resolves (or on a host
-  // where measure is a no-op), which drops the test to the radius fallback.
   region: IResponderRegion | undefined;
+  // Logical Pressability state, separate from the visible `pressed` cell: deactivation becomes
+  // logical immediately while its visual/onPressOut callback can remain behind the 130ms floor.
+  active: boolean;
+  activatedAt: number | undefined;
+  // True once delayPressIn elapsed (or was flushed by an honest early release). A touch that left
+  // before the delay can then activate only if it later re-enters the retention region.
+  delayElapsed: boolean;
+  // Reset on unmount. Async callbacks also check it, covering a timer callback already queued when
+  // its canceller ran.
+  disposed: boolean;
 }
 
 export function createPressRuntime(): IPressRuntime {
@@ -187,10 +188,42 @@ export function createPressRuntime(): IPressRuntime {
     longPressCancel: undefined,
     longPressFired: false,
     pressDelayCancel: undefined,
+    pressOutCancel: undefined,
     pressOrigin: undefined,
     driftedOut: false,
     region: undefined,
+    active: false,
+    activatedAt: undefined,
+    delayElapsed: false,
+    disposed: false,
   };
+}
+
+function cancelRuntimeTimer(
+  runtime: IPressRuntime,
+  key: 'longPressCancel' | 'pressDelayCancel' | 'pressOutCancel',
+): void {
+  const cancel = runtime[key];
+  if (cancel === undefined) return;
+  cancel();
+  runtime[key] = undefined;
+}
+
+// RN Pressability.reset(): cancel every timer and make any already-queued callback inert. The
+// adapter invokes this exactly once from its own unmount/destroy hook.
+export function disposePressRuntime(runtime: IPressRuntime): void {
+  if (runtime.disposed) return;
+  runtime.disposed = true;
+  cancelRuntimeTimer(runtime, 'longPressCancel');
+  cancelRuntimeTimer(runtime, 'pressDelayCancel');
+  cancelRuntimeTimer(runtime, 'pressOutCancel');
+  runtime.longPressFired = false;
+  runtime.pressOrigin = undefined;
+  runtime.driftedOut = false;
+  runtime.region = undefined;
+  runtime.active = false;
+  runtime.activatedAt = undefined;
+  runtime.delayElapsed = false;
 }
 
 // The per-frame frame-measure signature RN's UIManager.measure callback uses.
@@ -212,6 +245,8 @@ export interface IPressHost {
   // Schedule a one-shot timer and return its canceller. The adapter owns the actual setTimeout /
   // clearTimeout (timer scheduling is lifecycle); the machine only decides when to arm/cancel.
   schedule: (callback: () => void, ms: number) => () => void;
+  // RN reads Date.now() when activation/deactivation occurs. Injected for deterministic tests.
+  now: () => number;
 }
 
 export interface IPressMachineConfig {
@@ -222,6 +257,9 @@ export interface IPressMachineConfig {
   onLongPress?: IPressHandler;
   delayLongPress: number;
   unstable_pressDelay: number;
+  // Internal composition seam: plain Pressable uses RN's 130ms default, while every Touchable*
+  // config overrides Pressability to 0 and owns any caller-supplied timing in its own machine.
+  minPressDuration?: number;
   hitSlop?: IRectOffset;
   pressRetentionOffset?: IRectOffset;
 }
@@ -273,6 +311,7 @@ export function createPressHandlers(
     onLongPress,
     delayLongPress,
     unstable_pressDelay,
+    minPressDuration = DEFAULT_MIN_PRESS_DURATION_MS,
   } = config;
 
   // Per-edge offsets for the measured-rect retention test (RN's hitSlop + pressRectOffset).
@@ -300,21 +339,29 @@ export function createPressHandlers(
   }
 
   function clearLongPress(): void {
-    if (runtime.longPressCancel !== undefined) {
-      runtime.longPressCancel();
-      runtime.longPressCancel = undefined;
-    }
+    cancelRuntimeTimer(runtime, 'longPressCancel');
   }
 
-  // The real activation: flip pressed-state on, arm the long-press timer, fire onPressIn. Split
-  // out so unstable_pressDelay can defer it behind a timer while an early release flushes it.
+  function clearPressDelay(): void {
+    cancelRuntimeTimer(runtime, 'pressDelayCancel');
+  }
+
+  function clearPressOut(): void {
+    cancelRuntimeTimer(runtime, 'pressOutCancel');
+  }
+
   function activate(event: ISymbioteEvent): void {
+    if (runtime.disposed || runtime.active || runtime.driftedOut) return;
+    // A new grant or drift-back-in supersedes a delayed out from the previous active interval.
+    clearPressOut();
+    runtime.active = true;
+    runtime.activatedAt = host.now();
     dlog('Pressable pressIn');
     host.setPressed(true);
-    runtime.longPressFired = false;
-    if (onLongPress) {
+    if (!runtime.longPressFired && onLongPress) {
       runtime.longPressCancel = host.schedule(() => {
         runtime.longPressCancel = undefined;
+        if (runtime.disposed || !runtime.active || runtime.driftedOut) return;
         runtime.longPressFired = true;
         dlog('Pressable longPress timer fired');
         onLongPress(event);
@@ -323,52 +370,91 @@ export function createPressHandlers(
     onPressIn?.(event);
   }
 
-  // Flush a still-pending pressDelay timer immediately, so a pressOut/press that arrives before
-  // the delay elapsed still sees an activated press.
-  function flushPressDelay(event: ISymbioteEvent): void {
-    if (runtime.pressDelayCancel !== undefined) {
-      runtime.pressDelayCancel();
-      runtime.pressDelayCancel = undefined;
-      activate(event);
+  function deactivate(event: ISymbioteEvent): void {
+    if (runtime.disposed || !runtime.active) return;
+    runtime.active = false;
+    clearLongPress();
+    const activatedAt = runtime.activatedAt ?? host.now();
+    runtime.activatedAt = undefined;
+    const heldFor = Math.max(0, host.now() - activatedAt);
+    const wait = Math.max(minPressDuration - heldFor, 0);
+    const finish = (): void => {
+      runtime.pressOutCancel = undefined;
+      if (runtime.disposed) return;
+      host.setPressed(false);
+      onPressOut?.(event);
+    };
+    if (wait > 0) {
+      dlog(`Pressable pressOut deferred ${wait}ms`);
+      runtime.pressOutCancel = host.schedule(finish, wait);
+    } else {
+      finish();
     }
+  }
+
+  // An honest release arrives as press then pressOut. If it beat delayPressIn, activate now so the
+  // tap still flashes and calls onPressIn; a cancelled/out-of-bounds gesture never calls this path.
+  function completePressDelay(event: ISymbioteEvent): void {
+    if (runtime.pressDelayCancel !== undefined) clearPressDelay();
+    if (!runtime.delayElapsed) runtime.delayElapsed = true;
+    if (!runtime.driftedOut) activate(event);
+  }
+
+  function resetGesture(): void {
+    runtime.pressOrigin = undefined;
+    runtime.region = undefined;
+    runtime.driftedOut = false;
+    runtime.delayElapsed = false;
+    runtime.longPressFired = false;
   }
 
   return {
     handlePressIn(event: ISymbioteEvent): void {
+      if (runtime.disposed) return;
+      // A new grant cancels a delayed out from the prior gesture, matching Pressability's
+      // onResponderGrant -> _cancelPressOutDelayTimeout.
+      clearPressDelay();
+      clearLongPress();
+      clearPressOut();
+      runtime.active = false;
+      runtime.activatedAt = undefined;
+      runtime.longPressFired = false;
+      runtime.delayElapsed = false;
       runtime.pressOrigin = readPoint(event);
       runtime.driftedOut = false;
-      // Measure now so the move stream tests against the real frame, not a press-start radius.
       measureRegion(runtime, host.getMeasureFn());
       if (unstable_pressDelay > 0) {
         dlog(`Pressable pressIn deferred ${unstable_pressDelay}ms`);
         runtime.pressDelayCancel = host.schedule(() => {
           runtime.pressDelayCancel = undefined;
-          activate(event);
+          if (runtime.disposed) return;
+          runtime.delayElapsed = true;
+          if (!runtime.driftedOut) activate(event);
         }, unstable_pressDelay);
         return;
       }
+      runtime.delayElapsed = true;
       activate(event);
     },
     handlePressOut(event: ISymbioteEvent): void {
+      if (runtime.disposed) return;
       dlog('Pressable pressOut');
-      flushPressDelay(event);
+      // A cancellation before delayPressIn must stay inert. An honest release already flushed the
+      // delay in handlePress, because the engine emits press immediately before pressOut.
+      clearPressDelay();
       clearLongPress();
-      runtime.pressOrigin = undefined;
-      runtime.region = undefined;
-      host.setPressed(false);
-      onPressOut?.(event);
+      deactivate(event);
+      resetGesture();
     },
     handlePress(event: ISymbioteEvent): void {
+      if (runtime.disposed) return;
       dlog('Pressable press');
-      flushPressDelay(event);
+      completePressDelay(event);
       clearLongPress();
-      // A drift past the retention region cancels the tap (RN); reset and suppress.
       if (runtime.driftedOut) {
-        runtime.driftedOut = false;
         dlog('Pressable press suppressed by drift past retention region');
         return;
       }
-      // A fired long press cancels the tap: reset the flag and suppress onPress.
       if (runtime.longPressFired) {
         runtime.longPressFired = false;
         dlog('Pressable press suppressed by prior longPress');
@@ -376,11 +462,8 @@ export function createPressHandlers(
       }
       onPress?.(event);
     },
-    // Responder-move stream of the Pressable's own View. onPressMove fires on every move while
-    // the press is live (RN). Then the retention test: a move outside the measured region
-    // (expanded by hitSlop+pressRectOffset) fires an early pressOut and marks the tap suppressed;
-    // a move back inside re-activates.
     handleResponderMove(event: ISymbioteEvent): void {
+      if (runtime.disposed) return;
       onPressMove?.(event);
       const here = readPoint(event);
       if (!here) return;
@@ -389,13 +472,13 @@ export function createPressHandlers(
           dlog('Pressable drifted past retention region — deactivating');
           runtime.driftedOut = true;
           clearLongPress();
-          host.setPressed(false);
-          onPressOut?.(event);
+          // Before delayPressIn there was no activation, so there is no onPressOut to emit.
+          deactivate(event);
         }
       } else if (runtime.driftedOut) {
         dlog('Pressable returned inside retention region — reactivating');
         runtime.driftedOut = false;
-        activate(event);
+        if (runtime.delayElapsed) activate(event);
       }
     },
   };


### PR DESCRIPTION
## Summary

- align shared Pressable behavior with React Native delayed activation, retention-region re-entry, and the 130 ms active-duration floor
- let Touchable variants retain their zero-duration override
- centralize timer disposal and teardown guards in the shared state machine
- wire lifecycle cleanup and behavior consistently across React, Vue, Svelte, Angular, and Solid
- expand shared and adapter-specific regression coverage and changesets

## Test coverage

- shared Pressable state-machine tests
- Pressable/Touchable adapter tests across all five frameworks
- React clone-prop removal and render-prop regressions