### PR TITLE
test(ci): include Node test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,12 @@ adapter, for free.** We didn't build a test framework; we inherited RN's. The sa
 non-React renderer drive Fabric lets RN's testing, debugging, and native-module ecosystem come along
 without per-framework reinvention.
 
-- **Headless — `vitest`.** Colocated unit + smoke tests drive the engine against a fake
-  `nativeFabricUIManager` slot (`installFabric`) and read the committed Fabric props back — the real
-  commit path, no simulator, mirroring RN's own Fantom approach. ~500 tests run in Node in seconds,
-  and because the engine and `@symbiote-native/components` are the shared layer, one suite covers the logic
-  every adapter rides on. `pnpm test` at the workspace root.
+- **Headless — Vitest + `node:test`.** Colocated TypeScript unit + smoke tests drive the engine
+  against a fake `nativeFabricUIManager` slot (`installFabric`) and read committed Fabric props
+  back — the real commit path, no simulator, mirroring RN's own Fantom approach. Native ESM/CJS
+  tooling tests (the publish-output rewriter and app linker) run through Node's built-in runner.
+  `pnpm test` at the workspace root runs both layers; `pnpm test:vitest` and `pnpm test:node` narrow
+  one layer while developing.
 - **On-device — `Detox`.** End-to-end user-journey tests run against the real app on a
   simulator/emulator. One `canary-journeys` spec is mirrored across `examples/react`,
   `examples/vue-tsx`, `examples/vue-sfc`, and `examples/svelte` — the _same_ journeys, proving each
@@ -312,7 +313,7 @@ framework adapter.
 | ↳ M5.2 | Small native-module wrappers                     | one-dependency proxy packages closing the gap against Expo's package set one module at a time — Clipboard-class APIs first (same recipe as `@symbiote-native/slider`/`@symbiote-native/splash-screen`), plus lingering primitive-level gaps (persistent storage, safe-area edges beyond `SafeAreaView`)                                               | ⏳ planned |
 | ↳ M5.3 | Reanimated                                       | the largest remaining gap, saved for last — a full worklet-driven animation layer                                                                                                                                                                                                                                                                     | ⏳ planned |
 | **M6** | **Svelte adapter**                               | a DOM-shim adapter over stock compiled Svelte output driving the engine's mutation API — third non-React framework, full component parity                                                                                                                                                                                                             | ✅ done    |
-| **M7** | Solid adapter                                    | `solid-js/universal`'s `createRenderer` on the validated core, fourth non-React framework with full component parity (`createPortal`/`createTunnel`/`Animated`/`AppRegistry`), running on device and on the landing-page switcher                                                                                                            | ✅ done    |
+| **M7** | Solid adapter                                    | `solid-js/universal`'s `createRenderer` on the validated core, fourth non-React framework with full component parity (`createPortal`/`createTunnel`/`Animated`/`AppRegistry`), running on device and on the landing-page switcher                                                                                                                     | ✅ done    |
 | **M8** | Web _(stretch)_                                  | the same trees rendered to the web as a default platform target                                                                                                                                                                                                                                                                                       | 💭 maybe   |
 | **DX** | `create-symbiote` scaffolder                     | pins `react-native` + `react` at the app root so your app code imports only `@symbiote-native/*`, never `react-native`                                                                                                                                                                                                                                | ⏳ planned |
 
@@ -366,8 +367,10 @@ watching a monorepo this size.
 ```bash
 pnpm install
 pnpm typecheck           # tsc --build across the workspace
-pnpm test                # vitest — headless engine/adapter tests against a fake Fabric slot
-DEBUG=1 pnpm test        # same, with diagnostic logs on
+pnpm test                # all headless suites: Vitest + native ESM/CJS node:test files
+pnpm test:vitest         # engine/adapter tests against the fake Fabric slot only
+pnpm test:node           # release-tool and native-linker node:test suites only
+DEBUG=1 pnpm test        # all headless suites, with diagnostic logs on
 ```
 
 To build and run a canary on a simulator/emulator — and the Detox e2e journeys — follow the

--- a/apps/docs-site/src/content/docs/docs/testing.mdx
+++ b/apps/docs-site/src/content/docs/docs/testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Testing
-description: Headless component tests with Vitest, real-device journeys with Detox — the same spec across every adapter.
+description: Headless Vitest and Node-native suites, plus real-device Detox journeys across adapters.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -9,20 +9,24 @@ An app built with SymbioteNative is tested the same way as any other React Nativ
 app — SymbioteNative doesn't ask for a different tool. Two layers: headless
 component/integration tests, and real-device end-to-end journeys.
 
-## Component and integration tests — Vitest
+## Headless tests — Vitest and Node
 
-Unit and integration tests run headless, against a fake Fabric slot — no
-simulator, no device, no build step:
+Component and integration tests run against a fake Fabric slot — no simulator,
+device, or native build. Production-critical ESM/CommonJS tools use Node's
+built-in test runner so they exercise the exact module format shipped and run
+without a Vite transform:
 
 ```bash
-pnpm test   # vitest run
+pnpm test          # both layers
+pnpm test:vitest   # TypeScript component/integration suites
+pnpm test:node     # native .test.mjs/.test.cjs tooling suites
 ```
 
-Tests live next to what they exercise (`Component.test.ts(x)` beside
-`Component.ts(x)`), the same co-location convention across `core/`,
-`adapters/`, and the example apps. This is the layer for reducer logic,
-render-function output, and adapter-lifecycle behavior — anything that
-doesn't need a real native host to observe.
+Vitest tests live next to what they exercise (`Component.test.ts(x)` beside
+`Component.ts(x)`) across `core/`, `adapters/`, and `packages/`. The Node
+runner discovers every `*.test.mjs` and `*.test.cjs` under `scripts/` and
+`packages/`, excluding generated build and dependency trees. Adding such a
+suite therefore places it under the same root `pnpm test` command CI runs.
 
 ## End-to-end journeys — Detox
 
@@ -42,13 +46,13 @@ The `e2e:*` scripts live in each example's own `package.json`
   SymbioteNative replaces — it drives the real native views through Fabric's own
   accessibility tree, the same way it would for a plain React Native app. The
   same `canary-journeys` e2e spec runs unmodified across `examples/react`,
-  `examples/vue-sfc`, `examples/vue-tsx`, and `examples/svelte`, as long as
-  each exposes the same `testID`s. A component that mounts but behaves wrong
-  under one adapter — say, a native-driven `Animated` view that renders but
-  never actually animates — fails the same assertion the same way regardless
-  of which framework rendered it. `examples/angular` has its own Detox e2e
-  harness today but doesn't yet share that exact spec file. `examples/solid`
-  has no Detox e2e harness yet at all.
+  `examples/vue-sfc`, `examples/vue-tsx`, and `examples/svelte`, as long as each
+  exposes the same `testID`s. A component that mounts but behaves wrong under
+  one adapter — say, a native-driven `Animated` view that renders but never
+  actually animates — fails the same assertion the same way regardless of which
+  framework rendered it. `examples/angular` has its own Detox e2e harness today
+  but doesn't yet share that exact spec file. `examples/solid` has no Detox e2e
+  harness yet at all.
 </Aside>
 
 ## A gotcha specific to perpetual animations

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "emit-svelte-declarations": "node scripts/emit-svelte-declarations.mjs",
     "overlay-local-packages": "node scripts/overlay-local-packages.mjs",
     "check:bundle-isolation": "node scripts/check-bundle-framework-isolation.mjs",
-    "test": "vitest run",
+    "test": "pnpm run test:vitest && pnpm run test:node",
     "test:watch": "vitest",
     "bench": "NODE_OPTIONS=--max-semi-space-size=64 vitest bench --run",
     "docs:dev": "pnpm --filter @symbiote-native/docs-site dev",
@@ -34,7 +34,9 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm run build && changeset publish",
-    "trust:publishers": "node scripts/trust-publishers.mjs"
+    "trust:publishers": "node scripts/trust-publishers.mjs",
+    "test:vitest": "vitest run",
+    "test:node": "node scripts/run-node-tests.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",

--- a/scripts/fix-esm-extensions.test.mjs
+++ b/scripts/fix-esm-extensions.test.mjs
@@ -1,11 +1,14 @@
-// Run: `node --test scripts/fix-esm-extensions.test.mjs`. Uses node:test so it stays self-contained
-// in scripts/ (the vitest config only globs core/adapters/packages) with zero extra dependency.
+// Runs under root `pnpm test:node` discovery. Uses node:test so it stays self-contained in
+// scripts/ (Vitest owns the TypeScript/component suites) with zero extra dependency.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { rewriteEsmSpecifiers, fixEsmExtensions } from './fix-esm-extensions.mjs';
+import {
+  rewriteEsmSpecifiers,
+  fixEsmExtensions,
+} from './fix-esm-extensions.mjs';
 
 // A resolver stand-in: every relative spec gains `.js` unless it's the sentinel unresolved one.
 const addJs = spec => (spec === './missing' ? null : spec + '.js');
@@ -26,7 +29,10 @@ test('rewrites a real re-export specifier', () => {
 });
 
 test('rewrites a real dynamic import specifier', () => {
-  const { code, importsFixed } = rewriteEsmSpecifiers(`const m = import('./y');`, addJs);
+  const { code, importsFixed } = rewriteEsmSpecifiers(
+    `const m = import('./y');`,
+    addJs,
+  );
   assert.equal(code, `const m = import('./y.js');`);
   assert.equal(importsFixed, 1);
 });
@@ -93,7 +99,10 @@ test('a quote inside a regex literal does not desync the scanner', () => {
 test('a // inside a string URL is not treated as a comment', () => {
   const src = `const u = 'https://example.com/a'; export { m } from './m';`;
   const { code } = rewriteEsmSpecifiers(src, addJs);
-  assert.equal(code, `const u = 'https://example.com/a'; export { m } from './m.js';`);
+  assert.equal(
+    code,
+    `const u = 'https://example.com/a'; export { m } from './m.js';`,
+  );
 });
 
 test('division is not mistaken for a regex', () => {
@@ -131,7 +140,10 @@ test('an already-extensioned specifier is skipped via the resolver', () => {
 test('fixEsmExtensions resolves and scans .jsx output (jsx: preserve packages)', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-esm-jsx-'));
   try {
-    fs.writeFileSync(path.join(dir, 'View.jsx'), `export { helper } from './helper';`);
+    fs.writeFileSync(
+      path.join(dir, 'View.jsx'),
+      `export { helper } from './helper';`,
+    );
     fs.writeFileSync(path.join(dir, 'helper.js'), 'export const helper = 1;');
     fs.mkdirSync(path.join(dir, 'sub'));
     fs.writeFileSync(path.join(dir, 'sub', 'index.jsx'), 'export const s = 1;');
@@ -152,7 +164,10 @@ test('fixEsmExtensions resolves and scans .jsx output (jsx: preserve packages)',
     assert.match(entry, /from '\.\/sub\/index\.jsx'/);
 
     // The .jsx file itself is scanned, not just resolved to.
-    assert.match(fs.readFileSync(path.join(dir, 'View.jsx'), 'utf8'), /from '\.\/helper\.js'/);
+    assert.match(
+      fs.readFileSync(path.join(dir, 'View.jsx'), 'utf8'),
+      /from '\.\/helper\.js'/,
+    );
 
     assert.equal(importsFixed, 3); // View + sub in entry.js, helper in View.jsx
     assert.deepEqual(unresolved, []);

--- a/scripts/run-node-tests.mjs
+++ b/scripts/run-node-tests.mjs
@@ -1,0 +1,72 @@
+// Vitest intentionally owns TypeScript/component tests, but a few production-critical tools are
+// authored in native ESM/CommonJS and use node:test so they can execute without Vite transforms.
+// Discover those suites instead of hardcoding today's filenames: adding a new *.test.mjs/cjs under
+// scripts/ or packages/ automatically puts it under the root `pnpm test` and CI gate.
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+export const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), '..');
+const SEARCH_ROOTS = ['scripts', 'packages'];
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  'build',
+  'build-ngc',
+  'dist',
+  'e2e',
+  'node_modules',
+]);
+const NODE_TEST_FILE = /\.test\.(?:cjs|mjs)$/;
+
+function collectNodeTests(directory, repoRoot, found) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!EXCLUDED_DIRECTORIES.has(entry.name)) {
+        collectNodeTests(absolute, repoRoot, found);
+      }
+      continue;
+    }
+    if (entry.isFile() && NODE_TEST_FILE.test(entry.name)) {
+      found.push(path.relative(repoRoot, absolute));
+    }
+  }
+}
+
+export function discoverNodeTestFiles(repoRoot = REPO_ROOT) {
+  const found = [];
+  for (const searchRoot of SEARCH_ROOTS) {
+    const absolute = path.join(repoRoot, searchRoot);
+    if (fs.existsSync(absolute)) collectNodeTests(absolute, repoRoot, found);
+  }
+  return found.sort((a, b) => a.localeCompare(b));
+}
+
+export function runNodeTests({ repoRoot = REPO_ROOT, extraArgs = [] } = {}) {
+  const files = discoverNodeTestFiles(repoRoot);
+  if (files.length === 0) {
+    throw new Error(
+      `No Node test files found under ${SEARCH_ROOTS.join(', ')} in ${repoRoot}`,
+    );
+  }
+
+  console.log(`Running ${files.length} Node test file(s):`);
+  for (const file of files) console.log(`  ${file}`);
+
+  const result = spawnSync(
+    process.execPath,
+    ['--test', ...extraArgs, ...files],
+    {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    },
+  );
+  if (result.error !== undefined) throw result.error;
+  return result.status ?? 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  process.exitCode = runNodeTests({ extraArgs: process.argv.slice(2) });
+}

--- a/scripts/run-node-tests.test.mjs
+++ b/scripts/run-node-tests.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { discoverNodeTestFiles, REPO_ROOT } from './run-node-tests.mjs';
+
+function write(root, relativePath) {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, '// fixture\n');
+}
+
+test('discovers native Node suites in scripts/packages, sorted, excluding generated trees', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'symbiote-node-tests-'));
+  try {
+    write(root, 'scripts/z-last.test.mjs');
+    write(root, 'scripts/not-a-test.mjs');
+    write(root, 'packages/demo/src/a-first.test.cjs');
+    write(root, 'packages/demo/build/ignored.test.mjs');
+    write(root, 'packages/demo/build-ngc/ignored.test.cjs');
+    write(root, 'packages/demo/node_modules/dependency.test.mjs');
+    write(root, 'packages/demo/e2e/device.test.cjs');
+
+    assert.deepEqual(discoverNodeTestFiles(root), [
+      path.join('packages', 'demo', 'src', 'a-first.test.cjs'),
+      path.join('scripts', 'z-last.test.mjs'),
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the real repository discovery includes every release-critical Node suite', () => {
+  const found = discoverNodeTestFiles(REPO_ROOT);
+  assert.ok(
+    found.includes(path.join('scripts', 'fix-esm-extensions.test.mjs')),
+  );
+  assert.ok(found.includes(path.join('scripts', 'run-node-tests.test.mjs')));
+  assert.ok(
+    found.includes(
+      path.join('packages', 'expo-modules-link', 'src', 'index.test.cjs'),
+    ),
+  );
+  assert.ok(found.length >= 3);
+});


### PR DESCRIPTION
## Summary

- make the root `pnpm test` gate run both Vitest and native `node:test` suites
- discover `.test.mjs` and `.test.cjs` files under `scripts/` and `packages/` while excluding generated/dependency trees
- add discovery-runner coverage and strengthen the ESM extension rewriter tests
- document the combined and focused test commands in the README and docs site

## Test coverage

- `scripts/run-node-tests.test.mjs`
- `scripts/fix-esm-extensions.test.mjs`