### PR TITLE
fix(engine): bridge headless tasks to native AppRegistry

### DIFF
--- a/.changeset/headless-task-host-bridge.md
+++ b/.changeset/headless-task-host-bridge.md
@@ -1,0 +1,6 @@
+---
+'@symbiote-native/engine': patch
+---
+
+Bridge headless-task registrations into React Native's callable AppRegistry, including tasks
+registered before adapter bootstrap attaches the host.

--- a/adapters/vue/src/modules/app-registry/app-registry.test.ts
+++ b/adapters/vue/src/modules/app-registry/app-registry.test.ts
@@ -11,11 +11,8 @@
 // `setWrapperComponentProvider`/`unmountApplicationComponentAtRootTag`/`registerSection` are
 // covered below (the ones with either Vue-specific wiring or cheap, meaningful behavior to pin).
 // `getRunnable`/`getSections`/`getRegistry` are one-line Map/Set reads with no branch of their
-// own — N/A, trivial pass-through. `registerHeadlessTask`/`registerCancellableHeadlessTask`/
-// `startHeadlessTask`/`cancelHeadlessTask` are N/A here: framework-agnostic, driven by a native
-// module this file never installs, and have zero Vue-specific behavior — they belong in an
-// engine-level test, which does not exist yet. That absence is a real gap, not this file's job to
-// backfill silently.
+// own — N/A, trivial pass-through. Headless-task host forwarding and pre-bootstrap replay are
+// framework-agnostic and covered by core/engine/src/app-registry/app-registry.test.ts.
 
 import { defineComponent, h, type SetupContext } from '@vue/runtime-core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/core/engine/src/app-registry/app-registry.test.ts
+++ b/core/engine/src/app-registry/app-registry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createAppRegistry,
+  type IHostRegistrar,
+  type ITaskCancelProvider,
+  type ITaskProvider,
+} from './index';
+
+type IHostTask = {
+  taskProvider: ITaskProvider;
+  taskCancelProvider: ITaskCancelProvider;
+};
+
+function registry() {
+  return createAppRegistry<() => void, never>(() => () => {});
+}
+
+function host() {
+  const tasks = new Map<string, IHostTask>();
+  const registerCancellableHeadlessTask = vi.fn(
+    (
+      key: string,
+      taskProvider: ITaskProvider,
+      taskCancelProvider: ITaskCancelProvider,
+    ) => tasks.set(key, { taskProvider, taskCancelProvider }),
+  );
+  const registrar: IHostRegistrar = {
+    registerRunnable: key => key,
+    registerCancellableHeadlessTask,
+  };
+  return { registrar, tasks, registerCancellableHeadlessTask };
+}
+
+describe('AppRegistry headless-task host bridge', () => {
+  it('forwards a cancellable task registered after host attachment', async () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const native = host();
+    const task = vi.fn(async () => {});
+    const cancel = vi.fn();
+
+    setHostRegistrar(native.registrar);
+    AppRegistry.registerCancellableHeadlessTask(
+      'voice',
+      () => task,
+      () => cancel,
+    );
+
+    await native.tasks.get('voice')?.taskProvider()({ roomId: 'one' });
+    native.tasks.get('voice')?.taskCancelProvider()();
+    expect(task).toHaveBeenCalledWith({ roomId: 'one' });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('replays a plain task registered before bootstrap with a no-op canceller', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const native = host();
+    const taskProvider: ITaskProvider = () => async () => {};
+
+    AppRegistry.registerHeadlessTask('early', taskProvider);
+    setHostRegistrar(native.registrar);
+
+    expect(native.tasks.get('early')?.taskProvider).toBe(taskProvider);
+    expect(() =>
+      native.tasks.get('early')?.taskCancelProvider()(),
+    ).not.toThrow();
+  });
+
+  it('keeps custom registrars without headless support compatible', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    setHostRegistrar({ registerRunnable: key => key });
+
+    expect(() =>
+      AppRegistry.registerHeadlessTask('local-only', () => async () => {}),
+    ).not.toThrow();
+  });
+
+  it('does not replay twice to the same host and does replay to a replacement', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const first = host();
+    const replacement = host();
+
+    AppRegistry.registerHeadlessTask('task', () => async () => {});
+    setHostRegistrar(first.registrar);
+    setHostRegistrar(first.registrar);
+    setHostRegistrar(replacement.registrar);
+
+    expect(first.registerCancellableHeadlessTask).toHaveBeenCalledOnce();
+    expect(replacement.registerCancellableHeadlessTask).toHaveBeenCalledOnce();
+  });
+});

--- a/core/engine/src/app-registry/index.ts
+++ b/core/engine/src/app-registry/index.ts
@@ -6,11 +6,9 @@
 // the one thing each adapter supplies; everything else (registry bookkeeping, sections, the
 // host-registrar bridge, headless tasks) is byte-identical across adapters and lives here once.
 //
-// The catch: the native Fabric host invokes RN's AppRegistry (a registered callable module) by
-// app key, and it can't see ours. So registerComponent must also hand its runnable to RN's
-// registrar. Reached the same way shared reaches processColor: a dependency-injected seam
-// (setHostRegistrar), so the core stays react-native-free and the app glue wires the host once
-// at startup.
+// The catch: native invokes RN's registered callable AppRegistry for both surface runnables and
+// headless tasks; it cannot see this local registry. `setHostRegistrar` mirrors those native-facing
+// registrations there while the core remains react-native-free.
 
 import { getNativeModule } from '../native-modules';
 import { dlog } from '../debug';
@@ -47,11 +45,17 @@ export type ITaskCanceller = () => void;
 // Lazy provider of a task canceller, paired with a registered task.
 export type ITaskCancelProvider = () => ITaskCanceller;
 
-// The host's runnable registrar, RN's own AppRegistry. Injected by the app glue
-// so the adapter never imports react-native; native drives RN's AppRegistry, which
-// must hold our runnable under the app key for the surface to find it.
+// RN's own AppRegistry, injected by adapter bootstrap. Native drives this registrar for surface
+// runnables and headless tasks; the engine keeps only the framework-independent mirror.
 export interface IHostRegistrar {
   registerRunnable(appKey: string, run: IRunnable): string;
+  // Android starts headless work through RN's native-callable AppRegistry, not this local object.
+  // Bootstrap injects RN's AppRegistry here so the same task providers reach native too.
+  registerCancellableHeadlessTask?(
+    taskKey: string,
+    taskProvider: ITaskProvider,
+    taskCancelProvider: ITaskCancelProvider,
+  ): void;
   // Native unmount of a surface by rootTag. RN routes this through RendererProxy's
   // `unmountComponentAtNodeAndRemoveContainer` (AppRegistryImpl.js:212); the host
   // owns the container teardown, so we delegate when wired and no-op headless.
@@ -282,6 +286,11 @@ export function createAppRegistry<
       }
       taskProviders.set(taskKey, taskProvider);
       taskCancelProviders.set(taskKey, taskCancelProvider);
+      hostRegistrar?.registerCancellableHeadlessTask?.(
+        taskKey,
+        taskProvider,
+        taskCancelProvider,
+      );
     },
 
     startHeadlessTask(taskId, taskKey, data) {
@@ -304,7 +313,21 @@ export function createAppRegistry<
   return {
     AppRegistry,
     setHostRegistrar(registrar) {
+      if (hostRegistrar === registrar) return;
       hostRegistrar = registrar;
+      // Headless tasks are commonly registered before adapter bootstrap attaches RN's callable
+      // AppRegistry. Replay only this missing native-facing registry; app runnables retain their
+      // existing register-after-bootstrap contract.
+      for (const [taskKey, taskProvider] of taskProviders) {
+        const taskCancelProvider = taskCancelProviders.get(taskKey);
+        if (taskCancelProvider !== undefined) {
+          registrar.registerCancellableHeadlessTask?.(
+            taskKey,
+            taskProvider,
+            taskCancelProvider,
+          );
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary

- forward Symbiote headless-task registrations to React Native’s native-callable `AppRegistry`
- replay tasks registered before adapter bootstrap attaches the host registrar
- keep repeated attachment idempotent and replay tasks when the host is replaced
- preserve compatibility by making the host registrar capability optional
- retain local task start/cancellation as the deterministic headless-test seam

This is the framework-independent prerequisite for #58: Android `HeadlessJsTaskService` can only start tasks visible to React Native’s `AppRegistry`.

## Scope

The change does not alter app-runnable registration order and adds no adapter-specific implementations.

## Test coverage

- registration before and after host attachment
- repeated and replacement host attachment
- forwarding through the shared engine registry
- adapter AppRegistry contract compatibility