### PR TITLE
feat(android): add foreground-service lifecycle

### DIFF
--- a/.changeset/android-foreground-service.md
+++ b/.changeset/android-foreground-service.md
@@ -1,0 +1,7 @@
+---
+'@symbiote-native/foreground-service': minor
+---
+
+Add Android foreground-service lifecycle for microphone and media-playback types, including
+persistent notifications, native stop actions, state events, notification updates, and Headless JS
+delivery through every Symbiote adapter's AppRegistry.

--- a/.changeset/headless-task-host-bridge.md
+++ b/.changeset/headless-task-host-bridge.md
@@ -1,0 +1,6 @@
+---
+'@symbiote-native/engine': patch
+---
+
+Bridge headless-task registrations into React Native's callable AppRegistry, including tasks
+registered before adapter bootstrap attaches the host.

--- a/adapters/vue/src/modules/app-registry/app-registry.test.ts
+++ b/adapters/vue/src/modules/app-registry/app-registry.test.ts
@@ -11,11 +11,8 @@
 // `setWrapperComponentProvider`/`unmountApplicationComponentAtRootTag`/`registerSection` are
 // covered below (the ones with either Vue-specific wiring or cheap, meaningful behavior to pin).
 // `getRunnable`/`getSections`/`getRegistry` are one-line Map/Set reads with no branch of their
-// own — N/A, trivial pass-through. `registerHeadlessTask`/`registerCancellableHeadlessTask`/
-// `startHeadlessTask`/`cancelHeadlessTask` are N/A here: framework-agnostic, driven by a native
-// module this file never installs, and have zero Vue-specific behavior — they belong in an
-// engine-level test, which does not exist yet. That absence is a real gap, not this file's job to
-// backfill silently.
+// own — N/A, trivial pass-through. Headless-task host forwarding and pre-bootstrap replay are
+// framework-agnostic and covered by core/engine/src/app-registry/app-registry.test.ts.
 
 import { defineComponent, h, type SetupContext } from '@vue/runtime-core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/apps/docs-site/astro.config.mjs
+++ b/apps/docs-site/astro.config.mjs
@@ -277,6 +277,7 @@ export default defineConfig({
             { label: 'CSS parser', slug: 'docs/packages/css-parser' },
             { label: 'Test utils', slug: 'docs/packages/test-utils' },
             { label: 'Android host shims', slug: 'docs/packages/android' },
+            { label: 'Foreground service', slug: 'docs/packages/foreground-service' },
           ],
         },
         {

--- a/apps/docs-site/src/content/docs/docs/packages/foreground-service.mdx
+++ b/apps/docs-site/src/content/docs/docs/packages/foreground-service.mdx
@@ -1,0 +1,139 @@
+---
+title: Foreground service
+description: Android microphone/media-playback foreground-service lifecycle, persistent notifications, and Headless JS task delivery for every SymbioteNative adapter.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`@symbiote-native/foreground-service` keeps one Android task alive as a user-visible foreground
+service. It owns the native service lifecycle, notification, state events, and delivery into a
+Headless JS task registered through any adapter's `AppRegistry`.
+
+It does **not** record audio, play media, create a media session, or bypass Android's background
+launch rules. Application code owns that work; this package supplies the lifecycle container.
+
+| OS platform | Support                       |
+| ----------- | ----------------------------- |
+| iOS         | — use an iOS-specific service |
+| Android     | ✅ live                       |
+
+| Framework adapter | Support |
+| ----------------- | ------- |
+| React             | ✅ live |
+| Vue               | ✅ live |
+| Angular           | ✅ live |
+| Svelte            | ✅ live |
+| Solid             | ✅ live |
+
+The framework subpaths (`/react`, `/vue`, `/angular`, `/svelte`, `/solid`) are aliases of the same
+framework-independent API.
+
+## Installation
+
+```sh
+npm install @symbiote-native/foreground-service
+```
+
+React Native autolinking discovers the bundled Kotlin package and service declaration. Rebuild the
+Android application after installation.
+
+<Aside type="danger" title="Microphone mode still needs application permission">
+  The package contributes `FOREGROUND_SERVICE`, the microphone/media-playback
+  foreground-service permissions, and `WAKE_LOCK`. It deliberately does not
+  declare or request `RECORD_AUDIO`: an application using `types:
+  ['microphone']` must declare it and obtain the runtime grant first. Android
+  can also reject a foreground-service start made after the application has
+  already moved to the background.
+</Aside>
+
+Applications targeting Android 13 or later may request `POST_NOTIFICATIONS`. The service still has
+to create a foreground notification when the user denies that permission, although Android may
+show it only in the task manager rather than the notification drawer.
+
+## Usage
+
+```ts
+import { AppRegistry } from '@symbiote-native/react'; // or vue/angular/svelte/solid
+import {
+  addForegroundServiceListener,
+  startForegroundServiceAsync,
+  stopForegroundServiceAsync,
+} from '@symbiote-native/foreground-service';
+
+AppRegistry.registerCancellableHeadlessTask(
+  'voice-session',
+  () => async data => {
+    await runVoiceSession(data);
+  },
+  () => () => cancelVoiceSession(),
+);
+
+const subscription = addForegroundServiceListener(event => {
+  console.log(event.type, event.state.status);
+});
+
+await startForegroundServiceAsync({
+  taskKey: 'voice-session',
+  data: { roomId: 'room-1' },
+  types: ['microphone', 'mediaPlayback'],
+  notification: {
+    channelId: 'voice',
+    channelName: 'Voice sessions',
+    title: 'Voice session active',
+    body: 'Tap to return',
+    smallIcon: 'ic_voice',
+    stopActionLabel: 'Stop',
+  },
+});
+
+await stopForegroundServiceAsync();
+subscription.remove();
+```
+
+The start promise resolves after Android promotes the service and queues the registered Headless JS
+task. Resolving the task promise is the normal completion path and stops the service. Explicit JS
+stops and the optional notification action cancel the registered task before removing the
+notification.
+
+<Aside
+  type="caution"
+  title="Do not use an ordinary rejection as task completion"
+>
+  React Native does not finish native Headless JS accounting for an ordinary
+  rejected task promise. Handle expected failures inside the task and resolve,
+  call `stopForegroundServiceAsync()`, or set a finite `taskTimeoutMs` as a
+  backstop.
+</Aside>
+
+## API
+
+| Signature                                                                   | Description                                                                                            |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `startForegroundServiceAsync(options): Promise<void>`                       | Starts the single service and registered Headless JS task                                              |
+| `updateForegroundServiceNotificationAsync({ title, body? }): Promise<void>` | Replaces the visible title/body without restarting the task                                            |
+| `stopForegroundServiceAsync(): Promise<void>`                               | Cancels the active task and removes the foreground notification                                        |
+| `getForegroundServiceStateAsync(): Promise<IForegroundServiceState>`        | Reads the native authoritative state                                                                   |
+| `addForegroundServiceListener(listener): IEventSubscription`                | Subscribes to `starting`, `started`, `notificationUpdated`, `stopping`, `stopped`, and `failed` events |
+
+### Start options
+
+| Field           | Type                                   | Description                                                                             |
+| --------------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
+| `taskKey`       | `string`                               | Key registered through the active adapter's `AppRegistry`                               |
+| `data`          | `Record<string, unknown> \| undefined` | JSON-like data delivered to the task                                                    |
+| `types`         | `('microphone' \| 'mediaPlayback')[]`  | At least one foreground-service type                                                    |
+| `notification`  | `IForegroundServiceNotification`       | Channel, visible text, optional icon/stop action, and optional positive notification ID |
+| `taskTimeoutMs` | `number \| undefined`                  | Native Headless JS timeout; `0`/omitted means no timeout                                |
+
+Only one service may be active. State is one of `starting`, `running`, `stopping`, `stopped`, or
+`failed`, together with the task key, service types, notification ID, start time, terminal reason,
+and last native error.
+
+## Boundaries
+
+- `mediaPlayback` declares the Android service type; it is not an audio player or Media3 session.
+- `microphone` preserves permission to continue app-owned capture; it is not a recorder.
+- No boot receiver or automatic restart is installed.
+- The service does not make arbitrary background work exempt from Android scheduling limits.
+- The notification icon is a drawable or mipmap resource name; when omitted, the application icon
+  is used.

--- a/core/engine/src/app-registry/app-registry.test.ts
+++ b/core/engine/src/app-registry/app-registry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createAppRegistry,
+  type IHostRegistrar,
+  type ITaskCancelProvider,
+  type ITaskProvider,
+} from './index';
+
+type IHostTask = {
+  taskProvider: ITaskProvider;
+  taskCancelProvider: ITaskCancelProvider;
+};
+
+function registry() {
+  return createAppRegistry<() => void, never>(() => () => {});
+}
+
+function host() {
+  const tasks = new Map<string, IHostTask>();
+  const registerCancellableHeadlessTask = vi.fn(
+    (
+      key: string,
+      taskProvider: ITaskProvider,
+      taskCancelProvider: ITaskCancelProvider,
+    ) => tasks.set(key, { taskProvider, taskCancelProvider }),
+  );
+  const registrar: IHostRegistrar = {
+    registerRunnable: key => key,
+    registerCancellableHeadlessTask,
+  };
+  return { registrar, tasks, registerCancellableHeadlessTask };
+}
+
+describe('AppRegistry headless-task host bridge', () => {
+  it('forwards a cancellable task registered after host attachment', async () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const native = host();
+    const task = vi.fn(async () => {});
+    const cancel = vi.fn();
+
+    setHostRegistrar(native.registrar);
+    AppRegistry.registerCancellableHeadlessTask(
+      'voice',
+      () => task,
+      () => cancel,
+    );
+
+    await native.tasks.get('voice')?.taskProvider()({ roomId: 'one' });
+    native.tasks.get('voice')?.taskCancelProvider()();
+    expect(task).toHaveBeenCalledWith({ roomId: 'one' });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('replays a plain task registered before bootstrap with a no-op canceller', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const native = host();
+    const taskProvider: ITaskProvider = () => async () => {};
+
+    AppRegistry.registerHeadlessTask('early', taskProvider);
+    setHostRegistrar(native.registrar);
+
+    expect(native.tasks.get('early')?.taskProvider).toBe(taskProvider);
+    expect(() =>
+      native.tasks.get('early')?.taskCancelProvider()(),
+    ).not.toThrow();
+  });
+
+  it('keeps custom registrars without headless support compatible', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    setHostRegistrar({ registerRunnable: key => key });
+
+    expect(() =>
+      AppRegistry.registerHeadlessTask('local-only', () => async () => {}),
+    ).not.toThrow();
+  });
+
+  it('does not replay twice to the same host and does replay to a replacement', () => {
+    const { AppRegistry, setHostRegistrar } = registry();
+    const first = host();
+    const replacement = host();
+
+    AppRegistry.registerHeadlessTask('task', () => async () => {});
+    setHostRegistrar(first.registrar);
+    setHostRegistrar(first.registrar);
+    setHostRegistrar(replacement.registrar);
+
+    expect(first.registerCancellableHeadlessTask).toHaveBeenCalledOnce();
+    expect(replacement.registerCancellableHeadlessTask).toHaveBeenCalledOnce();
+  });
+});

--- a/core/engine/src/app-registry/index.ts
+++ b/core/engine/src/app-registry/index.ts
@@ -6,11 +6,9 @@
 // the one thing each adapter supplies; everything else (registry bookkeeping, sections, the
 // host-registrar bridge, headless tasks) is byte-identical across adapters and lives here once.
 //
-// The catch: the native Fabric host invokes RN's AppRegistry (a registered callable module) by
-// app key, and it can't see ours. So registerComponent must also hand its runnable to RN's
-// registrar. Reached the same way shared reaches processColor: a dependency-injected seam
-// (setHostRegistrar), so the core stays react-native-free and the app glue wires the host once
-// at startup.
+// The catch: native invokes RN's registered callable AppRegistry for both surface runnables and
+// headless tasks; it cannot see this local registry. `setHostRegistrar` mirrors those native-facing
+// registrations there while the core remains react-native-free.
 
 import { getNativeModule } from '../native-modules';
 import { dlog } from '../debug';
@@ -47,11 +45,17 @@ export type ITaskCanceller = () => void;
 // Lazy provider of a task canceller, paired with a registered task.
 export type ITaskCancelProvider = () => ITaskCanceller;
 
-// The host's runnable registrar, RN's own AppRegistry. Injected by the app glue
-// so the adapter never imports react-native; native drives RN's AppRegistry, which
-// must hold our runnable under the app key for the surface to find it.
+// RN's own AppRegistry, injected by adapter bootstrap. Native drives this registrar for surface
+// runnables and headless tasks; the engine keeps only the framework-independent mirror.
 export interface IHostRegistrar {
   registerRunnable(appKey: string, run: IRunnable): string;
+  // Android starts headless work through RN's native-callable AppRegistry, not this local object.
+  // Bootstrap injects RN's AppRegistry here so the same task providers reach native too.
+  registerCancellableHeadlessTask?(
+    taskKey: string,
+    taskProvider: ITaskProvider,
+    taskCancelProvider: ITaskCancelProvider,
+  ): void;
   // Native unmount of a surface by rootTag. RN routes this through RendererProxy's
   // `unmountComponentAtNodeAndRemoveContainer` (AppRegistryImpl.js:212); the host
   // owns the container teardown, so we delegate when wired and no-op headless.
@@ -282,6 +286,11 @@ export function createAppRegistry<
       }
       taskProviders.set(taskKey, taskProvider);
       taskCancelProviders.set(taskKey, taskCancelProvider);
+      hostRegistrar?.registerCancellableHeadlessTask?.(
+        taskKey,
+        taskProvider,
+        taskCancelProvider,
+      );
     },
 
     startHeadlessTask(taskId, taskKey, data) {
@@ -304,7 +313,21 @@ export function createAppRegistry<
   return {
     AppRegistry,
     setHostRegistrar(registrar) {
+      if (hostRegistrar === registrar) return;
       hostRegistrar = registrar;
+      // Headless tasks are commonly registered before adapter bootstrap attaches RN's callable
+      // AppRegistry. Replay only this missing native-facing registry; app runnables retain their
+      // existing register-after-bootstrap contract.
+      for (const [taskKey, taskProvider] of taskProviders) {
+        const taskCancelProvider = taskCancelProviders.get(taskKey);
+        if (taskCancelProvider !== undefined) {
+          registrar.registerCancellableHeadlessTask?.(
+            taskKey,
+            taskProvider,
+            taskCancelProvider,
+          );
+        }
+      }
     },
   };
 }

--- a/packages/foreground-service/README.md
+++ b/packages/foreground-service/README.md
@@ -1,0 +1,87 @@
+# @symbiote-native/foreground-service
+
+Android foreground-service lifecycle for SymbioteNative. It provides one active service with
+`microphone` and/or `mediaPlayback` types, a persistent notification, lifecycle state/events, a
+native stop action, and delivery into a task registered through any Symbiote adapter's `AppRegistry`.
+
+It does **not** record audio, play media, create a media session, or bypass Android's background
+launch rules. Those remain the application's responsibility.
+
+## Usage
+
+```ts
+import { AppRegistry } from '@symbiote-native/react'; // or vue/angular/svelte/solid
+import {
+  addForegroundServiceListener,
+  startForegroundServiceAsync,
+  stopForegroundServiceAsync,
+} from '@symbiote-native/foreground-service';
+
+AppRegistry.registerCancellableHeadlessTask(
+  'voice-session',
+  () => async data => {
+    // Keep this Promise pending for as long as the service should remain alive.
+    await runVoiceSession(data);
+  },
+  () => () => cancelVoiceSession(),
+);
+
+const subscription = addForegroundServiceListener(event => {
+  console.log(event.type, event.state);
+});
+
+await startForegroundServiceAsync({
+  taskKey: 'voice-session',
+  data: { roomId: 'room-1' },
+  types: ['microphone', 'mediaPlayback'],
+  notification: {
+    channelId: 'voice',
+    channelName: 'Voice sessions',
+    title: 'Voice session active',
+    body: 'Tap to return',
+    smallIcon: 'ic_voice',
+    stopActionLabel: 'Stop',
+  },
+});
+
+await stopForegroundServiceAsync();
+subscription.remove();
+```
+
+The start promise resolves after Android has promoted the service and begun the Headless JS
+runtime/task startup path. On a cold process, it does not wait for the task body itself to begin. If
+Android does not acknowledge startup within ten seconds, the promise rejects and the pending service
+is stopped. Resolving the task Promise is the normal completion path: React Native releases its wake
+lock and the service stops. An ordinary task rejection does not complete React Native's task
+accounting, so error paths should explicitly stop the service or use a finite `taskTimeoutMs`.
+Explicit and notification-action stops finish the active task before removing the notification.
+
+## Android requirements
+
+The package contributes the service declaration, foreground-service permissions, and the normal
+`WAKE_LOCK` permission React Native's Headless JS runtime uses while a task is active. It
+intentionally does **not** add `RECORD_AUDIO`: applications using the `microphone`
+type must declare and obtain that runtime permission themselves. Start microphone work while the
+application has foreground visibility; Android may reject a background start.
+
+Apps targeting Android 13 or later may request `POST_NOTIFICATIONS`. The foreground service still
+requires a notification even when the user does not permit it in the notification drawer.
+
+The notification `smallIcon` is an Android drawable or mipmap resource name. If omitted, the
+application icon is used. `stopActionLabel` adds a native action that stops the service without first
+opening a JS surface.
+
+## API
+
+```ts
+startForegroundServiceAsync(options): Promise<void>
+updateForegroundServiceNotificationAsync(options): Promise<void>
+stopForegroundServiceAsync(): Promise<void>
+getForegroundServiceStateAsync(): Promise<IForegroundServiceState>
+addForegroundServiceListener(listener): IEventSubscription
+```
+
+Notification updates replace the visible title/body while preserving the icon and native stop action.
+
+Only one service can be active. The state reports `starting`, `running`, `stopping`, `stopped`, or
+`failed`, plus its types, task key, notification ID, start time, stop reason, and last native error.

--- a/packages/foreground-service/android/build.gradle
+++ b/packages/foreground-service/android/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: "com.android.library"
+apply plugin: "org.jetbrains.kotlin.android"
+
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+android {
+  namespace = "com.symbiote.foregroundservice"
+  compileSdk = safeExtGet("compileSdkVersion", 36)
+
+  defaultConfig {
+    minSdk = safeExtGet("minSdkVersion", 24)
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+}
+
+repositories {
+  google()
+  mavenCentral()
+}
+
+dependencies {
+  implementation "com.facebook.react:react-android"
+  //noinspection GradleDependency -- match the repository's Android host-shim compatibility floor.
+  implementation "androidx.core:core-ktx:1.13.1"
+  testImplementation "junit:junit:4.13.2"
+}

--- a/packages/foreground-service/android/src/main/AndroidManifest.xml
+++ b/packages/foreground-service/android/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
+  <application>
+    <service
+      android:name=".SymbioteForegroundService"
+      android:exported="false"
+      android:foregroundServiceType="microphone|mediaPlayback"
+      android:stopWithTask="false" />
+  </application>
+</manifest>

--- a/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/ForegroundServiceRuntime.kt
+++ b/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/ForegroundServiceRuntime.kt
@@ -1,0 +1,277 @@
+package com.symbiote.foregroundservice
+
+import android.os.Bundle
+import android.os.ResultReceiver
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import java.lang.ref.WeakReference
+
+internal data class NotificationConfig(
+    val channelId: String,
+    val channelName: String,
+    val channelDescription: String?,
+    val title: String,
+    val body: String?,
+    val smallIcon: String?,
+    val stopActionLabel: String?,
+    val notificationId: Int,
+)
+
+internal data class StartConfig(
+    val sessionId: String,
+    val taskKey: String,
+    val data: Bundle,
+    val types: Set<String>,
+    val notification: NotificationConfig,
+    val taskTimeoutMs: Long,
+)
+
+internal data class NotificationUpdate(val title: String, val body: String?)
+
+internal data class ServiceError(val code: String, val message: String)
+
+internal data class ServiceSnapshot(
+    val status: String = STATUS_STOPPED,
+    val sessionId: String? = null,
+    val taskKey: String? = null,
+    val types: Set<String> = emptySet(),
+    val notificationId: Int? = null,
+    val startedAt: Long? = null,
+    val stopReason: String? = null,
+    val error: ServiceError? = null,
+) {
+  fun toWritableMap(): WritableMap =
+      Arguments.createMap().apply {
+        putString("status", status)
+        if (taskKey == null) putNull("taskKey") else putString("taskKey", taskKey)
+        putArray("types", types.toWritableArray())
+        if (notificationId == null) putNull("notificationId") else putInt("notificationId", notificationId)
+        if (startedAt == null) putNull("startedAt") else putDouble("startedAt", startedAt.toDouble())
+        if (stopReason == null) putNull("stopReason") else putString("stopReason", stopReason)
+        if (error == null) {
+          putNull("error")
+        } else {
+          putMap(
+              "error",
+              Arguments.createMap().apply {
+                putString("code", error.code)
+                putString("message", error.message)
+              },
+          )
+        }
+      }
+
+  companion object {
+    const val STATUS_STOPPED = "stopped"
+  }
+}
+
+private fun Set<String>.toWritableArray(): WritableArray =
+    Arguments.createArray().also { array -> forEach(array::pushString) }
+
+internal object ForegroundServiceRuntime {
+  private var snapshot = ServiceSnapshot()
+  private val terminalSessions = TerminalSessionRegistry()
+  private val startReceivers = OneShotSessionRegistry<ResultReceiver>()
+  private var module = WeakReference<SymbioteForegroundServiceModule>(null)
+  private var service = WeakReference<SymbioteForegroundService>(null)
+
+  @Synchronized
+  fun attachModule(value: SymbioteForegroundServiceModule) {
+    module = WeakReference(value)
+  }
+
+  @Synchronized
+  fun detachModule(value: SymbioteForegroundServiceModule) {
+    if (module.get() === value) module.clear()
+  }
+
+  @Synchronized
+  fun attachService(value: SymbioteForegroundService) {
+    service = WeakReference(value)
+  }
+
+  @Synchronized
+  fun detachService(value: SymbioteForegroundService) {
+    if (service.get() === value) service.clear()
+  }
+
+  @Synchronized fun current(): ServiceSnapshot = snapshot
+  @Synchronized fun wasTerminal(sessionId: String): Boolean = sessionId in terminalSessions
+  @Synchronized fun hasActiveSession(): Boolean = snapshot.status in ACTIVE_STATUSES
+  @Synchronized
+  fun hasActiveSessionOtherThan(sessionId: String): Boolean =
+      snapshot.status in ACTIVE_STATUSES && snapshot.sessionId != sessionId
+
+  @Synchronized
+  fun registerStartReceiver(sessionId: String, receiver: ResultReceiver) {
+    startReceivers.register(sessionId, receiver)
+  }
+
+  fun resolveStart(sessionId: String): Boolean {
+    val receiver = takeStartReceiver(sessionId) ?: return false
+    receiver.send(SymbioteForegroundServiceModule.RESULT_OK, null)
+    return true
+  }
+
+  fun rejectStart(sessionId: String, code: String, message: String): Boolean {
+    val receiver = takeStartReceiver(sessionId) ?: return false
+    receiver.send(
+        SymbioteForegroundServiceModule.RESULT_ERROR,
+        Bundle().apply {
+          putString(SymbioteForegroundServiceModule.RESULT_CODE, code)
+          putString(SymbioteForegroundServiceModule.RESULT_MESSAGE, message)
+        },
+    )
+    return true
+  }
+
+  fun tryStarting(config: StartConfig): Boolean {
+    val next = config.startingSnapshot()
+    val target =
+        synchronized(this) {
+          if (snapshot.status in ACTIVE_STATUSES || service.get() != null) return false
+          snapshot = next
+          module.get()
+        }
+    target?.emit("starting", next)
+    return true
+  }
+
+  fun admitService(config: StartConfig): Boolean {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (config.sessionId in terminalSessions) return false
+      if (snapshot.sessionId == config.sessionId && snapshot.status in ACTIVE_STATUSES) return true
+      if (snapshot.status in ACTIVE_STATUSES) return false
+      next = config.startingSnapshot()
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("starting", next)
+    return true
+  }
+
+  fun running(config: StartConfig) {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (snapshot.sessionId != config.sessionId || snapshot.status != "starting") return
+      next =
+          config.startingSnapshot().copy(
+              status = "running",
+              startedAt = System.currentTimeMillis(),
+          )
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("started", next)
+  }
+
+  fun notificationUpdated(sessionId: String) {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (snapshot.sessionId != sessionId || snapshot.status != "running") return
+      next = snapshot.copy(error = null)
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("notificationUpdated", next)
+  }
+
+  fun requestStop(reason: String): Boolean {
+    val target: SymbioteForegroundService?
+    val sessionId: String?
+    synchronized(this) {
+      if (snapshot.status !in ACTIVE_STATUSES) return false
+      sessionId = snapshot.sessionId
+      sessionId?.let(terminalSessions::remember)
+      target = service.get()
+    }
+    sessionId?.let {
+      rejectStart(it, SymbioteForegroundServiceModule.ERROR_START_CANCELLED, "Foreground service start was cancelled")
+    }
+    stopping(reason)
+    return target?.requestStop(reason) == true
+  }
+
+  fun stopping(reason: String) {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (snapshot.status !in STOPPABLE_STATUSES) return
+      next = snapshot.copy(status = "stopping", stopReason = reason, error = null)
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("stopping", next)
+  }
+
+  fun stopped(sessionId: String?, reason: String) {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (sessionId != null && snapshot.sessionId != null && snapshot.sessionId != sessionId) return
+      if (snapshot.status == "failed") return
+      if (snapshot.status == "stopped" && snapshot.stopReason == reason) return
+      if (sessionId != null && reason != SymbioteForegroundServiceModule.STOP_DESTROYED) {
+        terminalSessions.remember(sessionId)
+      }
+      next = snapshot.copy(status = "stopped", stopReason = reason, error = null)
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("stopped", next)
+    sessionId?.let {
+      rejectStart(it, SymbioteForegroundServiceModule.ERROR_START_CANCELLED, "Foreground service stopped before start completed")
+    }
+  }
+
+  fun failed(sessionId: String?, code: String, message: String) {
+    val target: SymbioteForegroundServiceModule?
+    val next: ServiceSnapshot
+    synchronized(this) {
+      if (sessionId == null && snapshot.status in ACTIVE_STATUSES) return
+      if (sessionId != null && snapshot.sessionId != null && snapshot.sessionId != sessionId) return
+      sessionId?.let(terminalSessions::remember)
+      next =
+          if (sessionId == null) {
+            ServiceSnapshot(
+                status = "failed",
+                stopReason = "startFailed",
+                error = ServiceError(code, message),
+            )
+          } else {
+            snapshot.copy(
+                status = "failed",
+                stopReason = "startFailed",
+                error = ServiceError(code, message),
+            )
+          }
+      snapshot = next
+      target = module.get()
+    }
+    target?.emit("failed", next)
+    sessionId?.let { rejectStart(it, code, message) }
+  }
+
+  fun updateNotification(options: NotificationUpdate): Boolean =
+      synchronized(this) { service.get() }?.updateNotification(options) == true
+
+  private fun takeStartReceiver(sessionId: String): ResultReceiver? = startReceivers.take(sessionId)
+
+  private fun StartConfig.startingSnapshot(): ServiceSnapshot =
+      ServiceSnapshot(
+          status = "starting",
+          sessionId = sessionId,
+          taskKey = taskKey,
+          types = types,
+          notificationId = notification.notificationId,
+      )
+
+  private val STOPPABLE_STATUSES = setOf("starting", "running")
+  private val ACTIVE_STATUSES = STOPPABLE_STATUSES + "stopping"
+}

--- a/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SessionRegistries.kt
+++ b/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SessionRegistries.kt
@@ -1,0 +1,53 @@
+package com.symbiote.foregroundservice
+
+/** Bounded tombstones for starts that must never be revived by a late/redelivered intent. */
+internal class TerminalSessionRegistry(private val capacity: Int = 32) {
+  private val sessionIds = LinkedHashSet<String>()
+
+  init {
+    require(capacity > 0) { "capacity must be positive" }
+  }
+
+  @Synchronized
+  fun remember(sessionId: String) {
+    sessionIds.remove(sessionId)
+    sessionIds.add(sessionId)
+    while (sessionIds.size > capacity) {
+      val iterator = sessionIds.iterator()
+      iterator.next()
+      iterator.remove()
+    }
+  }
+
+  @Synchronized operator fun contains(sessionId: String): Boolean = sessionId in sessionIds
+}
+
+/** Per-session values consumed by exactly one competing completion path. */
+internal class OneShotSessionRegistry<T> {
+  private val values = mutableMapOf<String, T>()
+
+  @Synchronized fun register(sessionId: String, value: T) {
+    values[sessionId] = value
+  }
+
+  @Synchronized fun take(sessionId: String): T? = values.remove(sessionId)
+}
+
+/** UI-thread-confined ownership of exactly the task started by this service. */
+internal class HeadlessTaskOwnership {
+  var taskId: Int? = null
+    private set
+
+  fun record(taskId: Int) {
+    check(this.taskId == null) { "A headless task is already active" }
+    this.taskId = taskId
+  }
+
+  fun finishIfOwned(taskId: Int): Boolean {
+    if (this.taskId != taskId) return false
+    this.taskId = null
+    return true
+  }
+
+  fun take(): Int? = taskId.also { taskId = null }
+}

--- a/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundService.kt
+++ b/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundService.kt
@@ -1,0 +1,428 @@
+package com.symbiote.foregroundservice
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.facebook.react.HeadlessJsTaskService
+import com.facebook.react.ReactInstanceEventListener
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaScriptModule
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+import com.facebook.react.jstasks.HeadlessJsTaskContext
+
+private interface AppRegistry : JavaScriptModule {
+  fun cancelHeadlessTask(taskId: Int, taskKey: String)
+}
+
+class SymbioteForegroundService : HeadlessJsTaskService() {
+  private var activeConfig: StartConfig? = null
+  private val taskOwnership = HeadlessTaskOwnership()
+  private var taskContext: ReactContext? = null
+  private var stopRequested = false
+  private var stopReason = SymbioteForegroundServiceModule.STOP_DESTROYED
+  private var removePendingContextListener: (() -> Unit)? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    ForegroundServiceRuntime.attachService(this)
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (intent?.action == SymbioteForegroundServiceModule.ACTION_STOP) {
+      val reason = SymbioteForegroundServiceModule.STOP_NOTIFICATION_ACTION
+      if (!ForegroundServiceRuntime.requestStop(reason)) requestStop(reason)
+      return START_NOT_STICKY
+    }
+
+    val config =
+        try {
+          requireNotNull(intent) { "Foreground service started without an intent" }.toStartConfig()
+        } catch (error: RuntimeException) {
+          if (activeConfig != null || ForegroundServiceRuntime.hasActiveSession()) {
+            return START_NOT_STICKY
+          }
+          fail(null, "E_INVALID_INTENT", error, startId)
+          return START_NOT_STICKY
+        }
+
+    val current = activeConfig
+    // A stop/timeout tombstone wins over redelivery, including while the original service instance
+    // is still unwinding. Otherwise a late same-session intent could re-promote its notification.
+    if (ForegroundServiceRuntime.wasTerminal(config.sessionId)) {
+      reportStartError(config, SymbioteForegroundServiceModule.ERROR_START_CANCELLED, "Foreground service start was cancelled")
+      if (current == null && !ForegroundServiceRuntime.hasActiveSessionOtherThan(config.sessionId)) {
+        stopReason = SymbioteForegroundServiceModule.STOP_REQUESTED
+        stopSelfResult(startId)
+      }
+      return START_NOT_STICKY
+    }
+    if (current?.sessionId == config.sessionId) {
+      return try {
+        // Keep notification updates made after the original intent instead of restoring stale text.
+        showForeground(current)
+        ForegroundServiceRuntime.resolveStart(config.sessionId)
+        START_REDELIVER_INTENT
+      } catch (error: SecurityException) {
+        fail(
+            current.sessionId,
+            SymbioteForegroundServiceModule.ERROR_PERMISSION_DENIED,
+            error,
+            startId,
+        )
+        START_NOT_STICKY
+      } catch (error: RuntimeException) {
+        fail(current.sessionId, "E_SERVICE_START", error, startId)
+        START_NOT_STICKY
+      }
+    }
+    if (current != null) {
+      reportStartError(config, "E_ALREADY_RUNNING", "A different foreground-service session is active")
+      return START_NOT_STICKY
+    }
+    if (!ForegroundServiceRuntime.admitService(config)) {
+      reportStartError(config, "E_ALREADY_RUNNING", "A foreground service is already active")
+      if (!ForegroundServiceRuntime.hasActiveSessionOtherThan(config.sessionId)) {
+        stopSelfResult(startId)
+      }
+      return START_NOT_STICKY
+    }
+
+    return try {
+      activeConfig = config
+      showForeground(config)
+      ForegroundServiceRuntime.running(config)
+      scheduleHeadlessTask(config)
+      // The task-start listener retains the payload only until a cold React context is ready.
+      activeConfig = config.copy(data = Bundle())
+      val acknowledged = ForegroundServiceRuntime.resolveStart(config.sessionId)
+      if (!acknowledged && ForegroundServiceRuntime.wasTerminal(config.sessionId)) {
+        requestStop(SymbioteForegroundServiceModule.STOP_START_FAILED)
+        START_NOT_STICKY
+      } else {
+        // No receiver is normal after process death/redelivery: the original JS caller no longer
+        // exists, but the persisted intent still owns a valid foreground/headless session.
+        START_REDELIVER_INTENT
+      }
+    } catch (error: SecurityException) {
+      fail(
+          config.sessionId,
+          SymbioteForegroundServiceModule.ERROR_PERMISSION_DENIED,
+          error,
+          startId,
+      )
+      START_NOT_STICKY
+    } catch (error: RuntimeException) {
+      fail(config.sessionId, "E_SERVICE_START", error, startId)
+      START_NOT_STICKY
+    }
+  }
+
+  override fun onHeadlessJsTaskFinish(taskId: Int) {
+    // HeadlessJsTaskContext broadcasts every task in the React context to every listener. Only the
+    // exact ID returned when this service started its task belongs to this lifecycle.
+    if (!taskOwnership.finishIfOwned(taskId)) return
+    detachTaskListener()
+    if (!stopRequested) stopReason = SymbioteForegroundServiceModule.STOP_TASK_FINISHED
+    stopSelf()
+  }
+
+  override fun onDestroy() {
+    clearPendingContextListener()
+    val shouldCancelTask = !stopRequested && taskOwnership.taskId != null
+    stopRequested = true
+    if (shouldCancelTask) cancelActiveTask()
+    // Stop may arrive after onCreate but before onStartCommand has populated activeConfig.
+    // The runtime already admitted that session, so use it to publish the terminal state.
+    val sessionId = activeConfig?.sessionId ?: ForegroundServiceRuntime.current().sessionId
+    activeConfig = null
+    stopForeground(STOP_FOREGROUND_REMOVE)
+    ForegroundServiceRuntime.detachService(this)
+    detachTaskListener()
+    if (sessionId != null) ForegroundServiceRuntime.stopped(sessionId, stopReason)
+    super.onDestroy()
+  }
+
+  internal fun requestStop(reason: String): Boolean {
+    if (stopRequested) return true
+    stopRequested = true
+    stopReason = reason
+    clearPendingContextListener()
+    cancelActiveTask()
+    stopForeground(STOP_FOREGROUND_REMOVE)
+    stopSelf()
+    return true
+  }
+
+  internal fun updateNotification(update: NotificationUpdate): Boolean {
+    if (stopRequested) return false
+    val current = activeConfig ?: return false
+    val updated =
+        current.copy(
+            notification =
+                current.notification.copy(
+                    title = update.title,
+                    body = update.body,
+                )
+        )
+    activeConfig = updated
+    getSystemService(NotificationManager::class.java)
+        .notify(updated.notification.notificationId, buildNotification(updated.notification))
+    ForegroundServiceRuntime.notificationUpdated(updated.sessionId)
+    return true
+  }
+
+  private fun scheduleHeadlessTask(config: StartConfig) {
+    acquireWakeLockNow(this)
+    val context = reactContext
+    if (context != null) {
+      startOwnedTask(context, config)
+      return
+    }
+    createReactContextAndScheduleTask(config)
+  }
+
+  @Suppress("DEPRECATION")
+  private fun createReactContextAndScheduleTask(config: StartConfig) {
+    lateinit var listener: ReactInstanceEventListener
+    listener =
+        object : ReactInstanceEventListener {
+          override fun onReactContextInitialized(context: ReactContext) {
+            clearPendingContextListener()
+            UiThreadUtil.runOnUiThread {
+              if (!stopRequested) startOwnedTask(context, config)
+            }
+          }
+        }
+
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
+      val host = checkNotNull(reactHost)
+      // A ready host may invoke the listener inline, so install its remover first.
+      removePendingContextListener = { host.removeReactInstanceEventListener(listener) }
+      host.addReactInstanceEventListener(listener)
+      host.start()
+    } else {
+      val manager = reactNativeHost.reactInstanceManager
+      removePendingContextListener = { manager.removeReactInstanceEventListener(listener) }
+      manager.addReactInstanceEventListener(listener)
+      manager.createReactContextInBackground()
+    }
+  }
+
+  private fun startOwnedTask(context: ReactContext, config: StartConfig) {
+    val tasks = HeadlessJsTaskContext.getInstance(context)
+    tasks.addTaskEventListener(this)
+    taskContext = context
+    taskOwnership.record(tasks.startTask(config.toTaskConfig()))
+  }
+
+  private fun StartConfig.toTaskConfig(): HeadlessJsTaskConfig =
+      HeadlessJsTaskConfig(
+          taskKey,
+          Arguments.fromBundle(data),
+          taskTimeoutMs,
+          true,
+      )
+
+  private fun cancelActiveTask() {
+    val taskId = taskOwnership.take() ?: return
+    val config = activeConfig
+    val context = taskContext
+    if (config != null && context != null) {
+      try {
+        context.getJSModule(AppRegistry::class.java).cancelHeadlessTask(taskId, config.taskKey)
+      } catch (_: RuntimeException) {
+        // Native completion below is authoritative even when JS is already unavailable.
+      }
+      val tasks = HeadlessJsTaskContext.getInstance(context)
+      if (tasks.isTaskRunning(taskId)) tasks.finishTask(taskId)
+    }
+  }
+
+  private fun detachTaskListener() {
+    taskContext?.let { HeadlessJsTaskContext.getInstance(it).removeTaskEventListener(this) }
+    taskContext = null
+  }
+
+  private fun clearPendingContextListener() {
+    removePendingContextListener?.invoke()
+    removePendingContextListener = null
+  }
+
+  private fun showForeground(config: StartConfig) {
+    createChannel(config.notification)
+    ServiceCompat.startForeground(
+        this,
+        config.notification.notificationId,
+        buildNotification(config.notification),
+        foregroundServiceTypeMask(config.types),
+    )
+  }
+
+  private fun createChannel(config: NotificationConfig) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val channel =
+        NotificationChannel(
+            config.channelId,
+            config.channelName,
+            NotificationManager.IMPORTANCE_LOW,
+        )
+    channel.description = config.channelDescription
+    getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+  }
+
+  private fun buildNotification(config: NotificationConfig): Notification {
+    val icon = resolveIcon(config.smallIcon)
+    val builder =
+        NotificationCompat.Builder(this, config.channelId)
+            .setSmallIcon(icon)
+            .setContentTitle(config.title)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+    config.body?.let(builder::setContentText)
+    launchPendingIntent()?.let(builder::setContentIntent)
+    config.stopActionLabel?.let { label ->
+      builder.addAction(icon, label, stopPendingIntent(config.notificationId))
+    }
+    return builder.build()
+  }
+
+  @SuppressLint("DiscouragedApi") // Resource names cross the JS/native boundary by design.
+  private fun resolveIcon(name: String?): Int {
+    if (name != null) {
+      val drawable = resources.getIdentifier(name, "drawable", packageName)
+      if (drawable != 0) return drawable
+      val mipmap = resources.getIdentifier(name, "mipmap", packageName)
+      require(mipmap != 0) { "Notification icon resource \"$name\" was not found" }
+      return mipmap
+    }
+    return applicationInfo.icon.also {
+      require(it != 0) { "The application has no notification icon" }
+    }
+  }
+
+  private fun launchPendingIntent(): PendingIntent? {
+    val launchIntent = packageManager.getLaunchIntentForPackage(packageName) ?: return null
+    return PendingIntent.getActivity(
+        this,
+        0,
+        launchIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+  }
+
+  private fun stopPendingIntent(notificationId: Int): PendingIntent =
+      PendingIntent.getService(
+          this,
+          notificationId,
+          Intent(this, SymbioteForegroundService::class.java).apply {
+            action = SymbioteForegroundServiceModule.ACTION_STOP
+          },
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+
+  private fun foregroundServiceTypeMask(types: Set<String>): Int {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return 0
+    var mask = 0
+    if (SymbioteForegroundServiceModule.TYPE_MEDIA_PLAYBACK in types) {
+      mask = mask or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+    }
+    if (
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            SymbioteForegroundServiceModule.TYPE_MICROPHONE in types
+    ) {
+      mask = mask or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+    }
+    return mask
+  }
+
+  private fun reportStartError(config: StartConfig, code: String, message: String) {
+    ForegroundServiceRuntime.rejectStart(config.sessionId, code, message)
+  }
+
+  private fun fail(
+      sessionId: String?,
+      code: String,
+      error: Throwable,
+      startId: Int,
+  ) {
+    val message = error.message ?: error.javaClass.simpleName
+    ForegroundServiceRuntime.failed(sessionId, code, message)
+    stopRequested = true
+    stopReason = SymbioteForegroundServiceModule.STOP_START_FAILED
+    clearPendingContextListener()
+    cancelActiveTask()
+    if (activeConfig?.sessionId == sessionId) activeConfig = null
+    stopForeground(STOP_FOREGROUND_REMOVE)
+    stopSelfResult(startId)
+  }
+
+  private fun Intent.toStartConfig(): StartConfig {
+    val types = requireNotNull(getStringArrayListExtra(EXTRA_TYPES)).toSet()
+    require(types.isNotEmpty()) { "Foreground service types are missing" }
+    return StartConfig(
+        sessionId = requireNotNull(getStringExtra(EXTRA_SESSION_ID)),
+        taskKey = requireNotNull(getStringExtra(EXTRA_TASK_KEY)),
+        data = getBundleExtra(EXTRA_DATA) ?: Bundle(),
+        types = types,
+        notification =
+            NotificationConfig(
+                channelId = requireNotNull(getStringExtra(EXTRA_CHANNEL_ID)),
+                channelName = requireNotNull(getStringExtra(EXTRA_CHANNEL_NAME)),
+                channelDescription = getStringExtra(EXTRA_CHANNEL_DESCRIPTION),
+                title = requireNotNull(getStringExtra(EXTRA_TITLE)),
+                body = getStringExtra(EXTRA_BODY),
+                smallIcon = getStringExtra(EXTRA_SMALL_ICON),
+                stopActionLabel = getStringExtra(EXTRA_STOP_ACTION_LABEL),
+                notificationId = getIntExtra(EXTRA_NOTIFICATION_ID, 0).also { require(it > 0) },
+            ),
+        taskTimeoutMs = getLongExtra(EXTRA_TASK_TIMEOUT, 0),
+    )
+  }
+
+  companion object {
+    private const val EXTRA_SESSION_ID = "sessionId"
+    private const val EXTRA_TASK_KEY = "taskKey"
+    private const val EXTRA_DATA = "data"
+    private const val EXTRA_TYPES = "types"
+    private const val EXTRA_CHANNEL_ID = "channelId"
+    private const val EXTRA_CHANNEL_NAME = "channelName"
+    private const val EXTRA_CHANNEL_DESCRIPTION = "channelDescription"
+    private const val EXTRA_TITLE = "title"
+    private const val EXTRA_BODY = "body"
+    private const val EXTRA_SMALL_ICON = "smallIcon"
+    private const val EXTRA_STOP_ACTION_LABEL = "stopActionLabel"
+    private const val EXTRA_NOTIFICATION_ID = "notificationId"
+    private const val EXTRA_TASK_TIMEOUT = "taskTimeoutMs"
+
+    internal fun startIntent(context: Context, config: StartConfig): Intent =
+        Intent(context, SymbioteForegroundService::class.java).apply {
+          putExtra(EXTRA_SESSION_ID, config.sessionId)
+          putExtra(EXTRA_TASK_KEY, config.taskKey)
+          putExtra(EXTRA_DATA, config.data)
+          putStringArrayListExtra(EXTRA_TYPES, ArrayList(config.types))
+          putExtra(EXTRA_CHANNEL_ID, config.notification.channelId)
+          putExtra(EXTRA_CHANNEL_NAME, config.notification.channelName)
+          putExtra(EXTRA_CHANNEL_DESCRIPTION, config.notification.channelDescription)
+          putExtra(EXTRA_TITLE, config.notification.title)
+          putExtra(EXTRA_BODY, config.notification.body)
+          putExtra(EXTRA_SMALL_ICON, config.notification.smallIcon)
+          putExtra(EXTRA_STOP_ACTION_LABEL, config.notification.stopActionLabel)
+          putExtra(EXTRA_NOTIFICATION_ID, config.notification.notificationId)
+          putExtra(EXTRA_TASK_TIMEOUT, config.taskTimeoutMs)
+        }
+  }
+}

--- a/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundServiceModule.kt
+++ b/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundServiceModule.kt
@@ -1,0 +1,322 @@
+package com.symbiote.foregroundservice
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.ResultReceiver
+import androidx.core.content.ContextCompat
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import java.util.UUID
+
+class SymbioteForegroundServiceModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+  @Volatile private var listenerCount = 0
+  private val mainHandler = Handler(Looper.getMainLooper())
+
+  override fun getName(): String = NAME
+
+  override fun initialize() {
+    super.initialize()
+    ForegroundServiceRuntime.attachModule(this)
+  }
+
+  override fun invalidate() {
+    ForegroundServiceRuntime.detachModule(this)
+    super.invalidate()
+  }
+
+  @ReactMethod
+  fun start(options: ReadableMap, promise: Promise) {
+    val config =
+        try {
+          parseStartConfig(options)
+        } catch (error: RuntimeException) {
+          promise.reject(ERROR_INVALID_OPTIONS, error.message, error)
+          return
+        }
+
+    if (
+        TYPE_MICROPHONE in config.types &&
+            ContextCompat.checkSelfPermission(
+                reactApplicationContext,
+                Manifest.permission.RECORD_AUDIO,
+            ) != PackageManager.PERMISSION_GRANTED
+    ) {
+      promise.reject(
+          ERROR_MICROPHONE_PERMISSION,
+          "RECORD_AUDIO must be granted before starting a microphone foreground service",
+      )
+      return
+    }
+    if (!ForegroundServiceRuntime.tryStarting(config)) {
+      promise.reject(ERROR_ALREADY_RUNNING, "A foreground service is already active")
+      return
+    }
+
+    val receiver =
+        object : ResultReceiver(mainHandler) {
+          override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
+            if (resultCode == RESULT_OK) {
+              promise.resolve(null)
+            } else {
+              promise.reject(
+                  resultData?.getString(RESULT_CODE) ?: ERROR_NATIVE,
+                  resultData?.getString(RESULT_MESSAGE) ?: "Foreground service failed to start",
+              )
+            }
+          }
+        }
+    ForegroundServiceRuntime.registerStartReceiver(config.sessionId, receiver)
+    scheduleStartTimeout(config.sessionId)
+
+    try {
+      ContextCompat.startForegroundService(
+          reactApplicationContext,
+          SymbioteForegroundService.startIntent(reactApplicationContext, config),
+      )
+    } catch (error: SecurityException) {
+      failStart(config, ERROR_PERMISSION_DENIED, error)
+    } catch (error: IllegalStateException) {
+      failStart(config, ERROR_START_NOT_ALLOWED, error)
+    } catch (error: RuntimeException) {
+      failStart(config, ERROR_NATIVE, error)
+    }
+  }
+
+  @ReactMethod
+  fun updateNotification(options: ReadableMap, promise: Promise) {
+    val update =
+        try {
+          NotificationUpdate(
+              title = options.requiredText("title"),
+              body = options.optionalString("body"),
+          )
+        } catch (error: RuntimeException) {
+          promise.reject(ERROR_INVALID_OPTIONS, error.message, error)
+          return
+        }
+    mainHandler.post {
+      try {
+        if (!ForegroundServiceRuntime.updateNotification(update)) {
+          promise.reject(ERROR_NOT_RUNNING, "No foreground service is running")
+        } else {
+          promise.resolve(null)
+        }
+      } catch (error: RuntimeException) {
+        promise.reject(ERROR_NATIVE, error.message, error)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun stop(promise: Promise) {
+    mainHandler.post {
+      try {
+        val current = ForegroundServiceRuntime.current()
+        if (current.status != ServiceSnapshot.STATUS_STOPPED && current.status != "failed") {
+          if (!ForegroundServiceRuntime.requestStop(STOP_REQUESTED)) {
+            reactApplicationContext.stopService(
+                Intent(reactApplicationContext, SymbioteForegroundService::class.java)
+            )
+            // No service was attached when requestStop took its snapshot. Publish terminal state
+            // now; a late intent carries a terminal session ID and will stop without reviving it.
+            ForegroundServiceRuntime.stopped(current.sessionId, STOP_REQUESTED)
+          }
+        }
+        promise.resolve(null)
+      } catch (error: RuntimeException) {
+        promise.reject(ERROR_NATIVE, error.message, error)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun getState(promise: Promise) {
+    promise.resolve(ForegroundServiceRuntime.current().toWritableMap())
+  }
+
+  @ReactMethod
+  fun addListener(eventType: String) {
+    if (eventType == EVENT_NAME) listenerCount += 1
+  }
+
+  @ReactMethod
+  fun removeListeners(count: Double) {
+    listenerCount = maxOf(0, listenerCount - count.toInt())
+  }
+
+  internal fun emit(eventType: String, snapshot: ServiceSnapshot) {
+    if (listenerCount == 0 || !reactApplicationContext.hasActiveReactInstance()) return
+    reactApplicationContext.emitDeviceEvent(
+        EVENT_NAME,
+        Arguments.createMap().apply {
+          putString("type", eventType)
+          putMap("state", snapshot.toWritableMap())
+        },
+    )
+  }
+
+  private fun scheduleStartTimeout(sessionId: String) {
+    mainHandler.postDelayed(
+        {
+          val message = "Foreground service did not acknowledge startup within ${START_ACK_TIMEOUT_MS}ms"
+          if (ForegroundServiceRuntime.rejectStart(sessionId, ERROR_START_TIMEOUT, message)) {
+            // The exact session is now terminal. Its eventual intent will stop itself; a global
+            // stopService() here could kill a newer session racing this timeout.
+            ForegroundServiceRuntime.failed(sessionId, ERROR_START_TIMEOUT, message)
+          }
+        },
+        START_ACK_TIMEOUT_MS,
+    )
+  }
+
+  private fun parseStartConfig(options: ReadableMap): StartConfig {
+    val notification = options.requiredMap("notification")
+    val data =
+        if (!options.hasKey("data") || options.isNull("data")) {
+          Bundle()
+        } else {
+          Arguments.toBundle(options.requiredMap("data")) ?: Bundle()
+        }
+    return StartConfig(
+        sessionId = UUID.randomUUID().toString(),
+        taskKey = options.requiredText("taskKey"),
+        data = data,
+        types = options.requiredTypes(),
+        notification =
+            NotificationConfig(
+                channelId = notification.requiredText("channelId"),
+                channelName = notification.requiredText("channelName"),
+                channelDescription = notification.optionalText("channelDescription"),
+                title = notification.requiredText("title"),
+                body = notification.optionalString("body"),
+                smallIcon = notification.optionalText("smallIcon"),
+                stopActionLabel = notification.optionalText("stopActionLabel"),
+                notificationId = notification.notificationId(),
+            ),
+        taskTimeoutMs = options.optionalNonNegativeLong("taskTimeoutMs"),
+    )
+  }
+
+  private fun ReadableMap.notificationId(): Int {
+    if (!hasKey("notificationId") || isNull("notificationId")) {
+      return DEFAULT_NOTIFICATION_ID
+    }
+    val raw = getDouble("notificationId")
+    require(raw > 0 && raw % 1.0 == 0.0 && raw <= Int.MAX_VALUE) {
+      "notification.notificationId must be a positive integer"
+    }
+    return raw.toInt()
+  }
+
+  private fun ReadableMap.optionalNonNegativeLong(key: String): Long {
+    if (!hasKey(key) || isNull(key)) return 0
+    require(getType(key) == ReadableType.Number) { "$key must be a number" }
+    val raw = getDouble(key)
+    require(raw.isFinite() && raw >= 0 && raw % 1.0 == 0.0 && raw <= MAX_SAFE_INTEGER) {
+      "$key must be a non-negative safe integer"
+    }
+    return raw.toLong()
+  }
+
+  private fun ReadableMap.requiredTypes(): Set<String> {
+    val array = requiredArray("types")
+    require(array.size() > 0) { "types must not be empty" }
+    return buildSet {
+      for (index in 0 until array.size()) {
+        require(array.getType(index) == ReadableType.String) { "types[$index] must be a string" }
+        val type = requireNotNull(array.getString(index))
+        require(type == TYPE_MICROPHONE || type == TYPE_MEDIA_PLAYBACK) {
+          "Unsupported foreground-service type: $type"
+        }
+        add(type)
+      }
+    }
+  }
+
+  private fun ReadableMap.requiredText(key: String): String {
+    require(hasKey(key) && !isNull(key) && getType(key) == ReadableType.String) {
+      "$key must be a string"
+    }
+    return requireNotNull(getString(key)).trim().also {
+      require(it.isNotEmpty()) { "$key must not be empty" }
+    }
+  }
+
+  private fun ReadableMap.optionalText(key: String): String? {
+    val value = optionalString(key)?.trim() ?: return null
+    require(value.isNotEmpty()) { "$key must not be empty" }
+    return value
+  }
+
+  private fun ReadableMap.optionalString(key: String): String? {
+    if (!hasKey(key) || isNull(key)) return null
+    require(getType(key) == ReadableType.String) { "$key must be a string" }
+    return getString(key)
+  }
+
+  private fun ReadableMap.requiredMap(key: String): ReadableMap {
+    require(hasKey(key) && !isNull(key) && getType(key) == ReadableType.Map) {
+      "$key must be an object"
+    }
+    return requireNotNull(getMap(key))
+  }
+
+  private fun ReadableMap.requiredArray(key: String): ReadableArray {
+    require(hasKey(key) && !isNull(key) && getType(key) == ReadableType.Array) {
+      "$key must be an array"
+    }
+    return requireNotNull(getArray(key))
+  }
+
+  private fun failStart(config: StartConfig, code: String, error: RuntimeException) {
+    ForegroundServiceRuntime.failed(
+        config.sessionId,
+        code,
+        error.message ?: error.javaClass.simpleName,
+    )
+  }
+
+  companion object {
+    const val NAME = "SymbioteForegroundService"
+    const val EVENT_NAME = "symbioteForegroundServiceStateChanged"
+    const val TYPE_MICROPHONE = "microphone"
+    const val TYPE_MEDIA_PLAYBACK = "mediaPlayback"
+    const val DEFAULT_NOTIFICATION_ID = 13_158
+
+    const val ACTION_STOP = "com.symbiote.foregroundservice.STOP"
+    const val STOP_REQUESTED = "requested"
+    const val STOP_NOTIFICATION_ACTION = "notificationAction"
+    const val STOP_TASK_FINISHED = "taskFinished"
+    const val STOP_DESTROYED = "destroyed"
+    const val STOP_START_FAILED = "startFailed"
+
+    const val RESULT_OK = 0
+    const val RESULT_ERROR = 1
+    const val RESULT_CODE = "code"
+    const val RESULT_MESSAGE = "message"
+
+    const val ERROR_INVALID_OPTIONS = "E_INVALID_OPTIONS"
+    const val ERROR_ALREADY_RUNNING = "E_ALREADY_RUNNING"
+    const val ERROR_MICROPHONE_PERMISSION = "E_MICROPHONE_PERMISSION"
+    const val ERROR_PERMISSION_DENIED = "E_PERMISSION_DENIED"
+    const val ERROR_START_NOT_ALLOWED = "E_START_NOT_ALLOWED"
+    const val ERROR_START_CANCELLED = "E_START_CANCELLED"
+    const val ERROR_START_TIMEOUT = "E_START_TIMEOUT"
+    const val ERROR_NOT_RUNNING = "E_NOT_RUNNING"
+    const val ERROR_NATIVE = "E_NATIVE"
+    private const val START_ACK_TIMEOUT_MS = 10_000L
+    private const val MAX_SAFE_INTEGER = 9_007_199_254_740_991.0
+  }
+}

--- a/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundServicePackage.kt
+++ b/packages/foreground-service/android/src/main/java/com/symbiote/foregroundservice/SymbioteForegroundServicePackage.kt
@@ -1,0 +1,15 @@
+package com.symbiote.foregroundservice
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class SymbioteForegroundServicePackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+      listOf(SymbioteForegroundServiceModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+      emptyList()
+}

--- a/packages/foreground-service/android/src/test/java/com/symbiote/foregroundservice/SessionRegistriesTest.kt
+++ b/packages/foreground-service/android/src/test/java/com/symbiote/foregroundservice/SessionRegistriesTest.kt
@@ -1,0 +1,66 @@
+package com.symbiote.foregroundservice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionRegistriesTest {
+  @Test
+  fun `terminal sessions coexist`() {
+    val registry = TerminalSessionRegistry()
+
+    registry.remember("old-session")
+    registry.remember("new-session")
+
+    assertTrue("old-session" in registry)
+    assertTrue("new-session" in registry)
+  }
+
+  @Test
+  fun `terminal registry stays bounded and retains refreshed sessions`() {
+    val registry = TerminalSessionRegistry(capacity = 2)
+
+    registry.remember("first")
+    registry.remember("second")
+    registry.remember("first")
+    registry.remember("third")
+
+    assertTrue("first" in registry)
+    assertTrue("third" in registry)
+    assertFalse("second" in registry)
+  }
+
+  @Test
+  fun `one-shot values settle once without consuming another session`() {
+    val registry = OneShotSessionRegistry<String>()
+    registry.register("first", "one")
+    registry.register("second", "two")
+
+    assertEquals("one", registry.take("first"))
+    assertNull(registry.take("first"))
+    assertEquals("two", registry.take("second"))
+  }
+
+  @Test
+  fun `headless ownership ignores another task and clears only its own`() {
+    val ownership = HeadlessTaskOwnership()
+
+    ownership.record(7)
+
+    assertFalse(ownership.finishIfOwned(8))
+    assertEquals(7, ownership.taskId)
+    assertTrue(ownership.finishIfOwned(7))
+    assertNull(ownership.taskId)
+  }
+
+  @Test
+  fun `headless ownership can be taken only once for cancellation`() {
+    val ownership = HeadlessTaskOwnership()
+    ownership.record(9)
+
+    assertEquals(9, ownership.take())
+    assertNull(ownership.take())
+  }
+}

--- a/packages/foreground-service/package.json
+++ b/packages/foreground-service/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@symbiote-native/foreground-service",
+  "version": "0.0.1",
+  "description": "Android foreground-service lifecycle for SymbioteNative \u2014 microphone/media-playback service types, persistent notifications, state events, and React Native headless-task delivery through one framework-agnostic API.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OneEyed1366/symbiote-native.git",
+    "directory": "packages/foreground-service"
+  },
+  "homepage": "https://github.com/OneEyed1366/symbiote-native/tree/master/packages/foreground-service#readme",
+  "bugs": {
+    "url": "https://github.com/OneEyed1366/symbiote-native/issues"
+  },
+  "author": "Andrey Prokopenko <psevdoproger@gmail.com>",
+  "type": "module",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./react": "./src/index.ts",
+    "./vue": "./src/index.ts",
+    "./svelte": "./src/index.ts",
+    "./solid": "./src/index.ts",
+    "./angular": "./src/index.ts"
+  },
+  "files": [
+    "android",
+    "!android/build",
+    "!android/src/test",
+    "build",
+    "react-native.config.cjs"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./build/index.js",
+    "module": "./build/index.js",
+    "types": "./build/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "./react": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "./vue": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "./svelte": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "./solid": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      },
+      "./angular": {
+        "types": "./build/index.d.ts",
+        "default": "./build/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --build",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "peerDependencies": {
+    "@symbiote-native/engine": "workspace:^",
+    "react-native": ">=0.86"
+  },
+  "devDependencies": {
+    "@symbiote-native/engine": "workspace:*",
+    "react-native": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/foreground-service/react-native.config.cjs
+++ b/packages/foreground-service/react-native.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: './android',
+        packageImportPath:
+          'import com.symbiote.foregroundservice.SymbioteForegroundServicePackage;',
+        packageInstance: 'new SymbioteForegroundServicePackage()',
+      },
+      ios: null,
+    },
+  },
+};

--- a/packages/foreground-service/src/index.test.ts
+++ b/packages/foreground-service/src/index.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const listeners = new Map<string, (payload: unknown) => void>();
+const RUNNING_STATE = {
+  status: 'running' as const,
+  taskKey: 'voice',
+  types: ['microphone' as const],
+  notificationId: 7,
+  startedAt: 100,
+  stopReason: null,
+  error: null,
+};
+const native = {
+  start: vi.fn(async () => {}),
+  updateNotification: vi.fn(async () => {}),
+  stop: vi.fn(async () => {}),
+  getState: vi.fn(async () => RUNNING_STATE),
+  addListener: vi.fn(),
+  removeListeners: vi.fn(),
+};
+
+vi.mock('@symbiote-native/engine', () => ({
+  getEnforcingNativeModule: () => native,
+  NativeEventEmitter: class {
+    addListener(event: string, listener: (payload: unknown) => void) {
+      native.addListener(event);
+      listeners.set(event, listener);
+      return {
+        remove: () => {
+          listeners.delete(event);
+          native.removeListeners(1);
+        },
+      };
+    }
+  },
+}));
+
+const api = await import('./index');
+
+const OPTIONS = {
+  taskKey: 'voice',
+  data: { roomId: 'room-1' },
+  types: ['microphone', 'mediaPlayback'] as const,
+  notification: {
+    channelId: 'voice',
+    channelName: 'Voice',
+    channelDescription: 'Voice work',
+    title: 'Active',
+    smallIcon: 'ic_voice',
+    stopActionLabel: 'Stop',
+    notificationId: 7,
+  },
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  listeners.clear();
+});
+
+describe('foreground service API', () => {
+  it('delegates a start request to the native contract owner', async () => {
+    await api.startForegroundServiceAsync(OPTIONS);
+    expect(native.start).toHaveBeenCalledWith(OPTIONS);
+  });
+
+  it('updates the notification and stops through native', async () => {
+    const notification = { title: 'Updated', body: 'Still active' };
+    await api.updateForegroundServiceNotificationAsync(notification);
+    await api.stopForegroundServiceAsync();
+    expect(native.updateNotification).toHaveBeenCalledWith(notification);
+    expect(native.stop).toHaveBeenCalledOnce();
+  });
+
+  it('returns the native state', async () => {
+    await expect(api.getForegroundServiceStateAsync()).resolves.toBe(
+      RUNNING_STATE,
+    );
+  });
+
+  it('delivers lifecycle events and balances native listener counters', () => {
+    const listener = vi.fn();
+    const subscription = api.addForegroundServiceListener(listener);
+    listeners.get('symbioteForegroundServiceStateChanged')?.({
+      type: 'started',
+      state: RUNNING_STATE,
+    });
+    expect(listener).toHaveBeenCalledOnce();
+    subscription.remove();
+    expect(native.addListener).toHaveBeenCalledWith(
+      'symbioteForegroundServiceStateChanged',
+    );
+    expect(native.removeListeners).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/foreground-service/src/index.ts
+++ b/packages/foreground-service/src/index.ts
@@ -1,0 +1,63 @@
+import {
+  NativeEventEmitter,
+  type IEventSubscription,
+} from '@symbiote-native/engine';
+import {
+  FOREGROUND_SERVICE_EVENT,
+  requireForegroundServiceModule,
+} from './native-module';
+import type {
+  ForegroundServiceListener,
+  IForegroundServiceEvent,
+  IForegroundServiceState,
+  IStartForegroundServiceOptions,
+  IUpdateForegroundServiceNotificationOptions,
+} from './types';
+
+export function startForegroundServiceAsync(
+  options: IStartForegroundServiceOptions,
+): Promise<void> {
+  return requireForegroundServiceModule().start(options);
+}
+
+export function updateForegroundServiceNotificationAsync(
+  options: IUpdateForegroundServiceNotificationOptions,
+): Promise<void> {
+  return requireForegroundServiceModule().updateNotification(options);
+}
+
+export function stopForegroundServiceAsync(): Promise<void> {
+  return requireForegroundServiceModule().stop();
+}
+
+export function getForegroundServiceStateAsync(): Promise<IForegroundServiceState> {
+  return requireForegroundServiceModule().getState();
+}
+
+export function addForegroundServiceListener(
+  listener: ForegroundServiceListener,
+): IEventSubscription {
+  const module = requireForegroundServiceModule();
+  return new NativeEventEmitter(module).addListener(
+    FOREGROUND_SERVICE_EVENT,
+    payload => {
+      // This package owns both sides of the event contract; narrow once at the native boundary.
+      listener(payload as IForegroundServiceEvent);
+    },
+  );
+}
+
+export type {
+  ForegroundServiceEventType,
+  ForegroundServiceListener,
+  ForegroundServiceStatus,
+  ForegroundServiceStopReason,
+  ForegroundServiceType,
+  IForegroundServiceError,
+  IForegroundServiceEvent,
+  IForegroundServiceNotification,
+  IForegroundServiceState,
+  IStartForegroundServiceOptions,
+  IUpdateForegroundServiceNotificationOptions,
+} from './types';
+export type { IEventSubscription } from '@symbiote-native/engine';

--- a/packages/foreground-service/src/native-module.ts
+++ b/packages/foreground-service/src/native-module.ts
@@ -1,0 +1,25 @@
+import {
+  getEnforcingNativeModule,
+  type IEventEmitterModule,
+} from '@symbiote-native/engine';
+import type {
+  IForegroundServiceState,
+  IStartForegroundServiceOptions,
+  IUpdateForegroundServiceNotificationOptions,
+} from './types';
+
+export const FOREGROUND_SERVICE_EVENT = 'symbioteForegroundServiceStateChanged';
+const MODULE_NAME = 'SymbioteForegroundService';
+
+export interface INativeForegroundServiceModule extends IEventEmitterModule {
+  start(options: IStartForegroundServiceOptions): Promise<void>;
+  updateNotification(
+    options: IUpdateForegroundServiceNotificationOptions,
+  ): Promise<void>;
+  stop(): Promise<void>;
+  getState(): Promise<IForegroundServiceState>;
+}
+
+export function requireForegroundServiceModule(): INativeForegroundServiceModule {
+  return getEnforcingNativeModule<INativeForegroundServiceModule>(MODULE_NAME);
+}

--- a/packages/foreground-service/src/package-contract.test.ts
+++ b/packages/foreground-service/src/package-contract.test.ts
@@ -1,0 +1,77 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const root = fileURLToPath(new URL('..', import.meta.url));
+const config = require(`${root}/react-native.config.cjs`) as {
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: string;
+        packageImportPath: string;
+        packageInstance: string;
+      };
+      ios: null;
+    };
+  };
+};
+const packageJson = JSON.parse(
+  readFileSync(`${root}/package.json`, 'utf8'),
+) as {
+  files: string[];
+  exports: Record<string, unknown>;
+  publishConfig: { exports: Record<string, unknown> };
+};
+const manifest = readFileSync(
+  `${root}/android/src/main/AndroidManifest.xml`,
+  'utf8',
+);
+
+describe('foreground-service native package contract', () => {
+  it('autolinks the Android package and has no iOS half', () => {
+    expect(config.dependency.platforms).toEqual({
+      android: {
+        sourceDir: './android',
+        packageImportPath:
+          'import com.symbiote.foregroundservice.SymbioteForegroundServicePackage;',
+        packageInstance: 'new SymbioteForegroundServicePackage()',
+      },
+      ios: null,
+    });
+  });
+
+  it('packs the native source and built JS surface without development tests', () => {
+    expect(packageJson.files).toEqual(
+      expect.arrayContaining([
+        'android',
+        '!android/build',
+        '!android/src/test',
+        'build',
+        'react-native.config.cjs',
+      ]),
+    );
+    expect(Object.keys(packageJson.publishConfig.exports).sort()).toEqual(
+      Object.keys(packageJson.exports).sort(),
+    );
+  });
+
+  it('declares only the service and runtime permissions it owns', () => {
+    expect(manifest).toContain('android.permission.FOREGROUND_SERVICE');
+    expect(manifest).toContain('android.permission.WAKE_LOCK');
+    expect(manifest).toContain(
+      'android.permission.FOREGROUND_SERVICE_MICROPHONE',
+    );
+    expect(manifest).toContain(
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+    );
+    expect(manifest).toContain('android:name=".SymbioteForegroundService"');
+    expect(manifest).toContain(
+      'android:foregroundServiceType="microphone|mediaPlayback"',
+    );
+    expect(manifest).toContain('android:stopWithTask="false"');
+    expect(manifest).not.toContain('android.permission.RECORD_AUDIO');
+    expect(manifest).not.toContain('android.permission.POST_NOTIFICATIONS');
+  });
+});

--- a/packages/foreground-service/src/types.ts
+++ b/packages/foreground-service/src/types.ts
@@ -1,0 +1,75 @@
+export type ForegroundServiceType = 'microphone' | 'mediaPlayback';
+
+export type ForegroundServiceStatus =
+  'stopped' | 'starting' | 'running' | 'stopping' | 'failed';
+
+export type ForegroundServiceStopReason =
+  | 'requested'
+  | 'notificationAction'
+  | 'taskFinished'
+  | 'destroyed'
+  | 'startFailed';
+
+export interface IForegroundServiceNotification {
+  channelId: string;
+  channelName: string;
+  channelDescription?: string;
+  title: string;
+  body?: string;
+  /** Android drawable or mipmap resource name. Falls back to the application icon. */
+  smallIcon?: string;
+  /** Adds a notification action that stops the native service. */
+  stopActionLabel?: string;
+  /** Stable positive notification ID. Defaults to 13,158. */
+  notificationId?: number;
+}
+
+export interface IStartForegroundServiceOptions {
+  /** Key registered through the active adapter's AppRegistry. */
+  taskKey: string;
+  /** JSON-like payload delivered to the headless task. */
+  data?: Record<string, unknown>;
+  /** At least one type is required; duplicates are removed. */
+  types: readonly ForegroundServiceType[];
+  notification: IForegroundServiceNotification;
+  /** Headless-task timeout. Zero means no timeout and is the default. */
+  taskTimeoutMs?: number;
+}
+
+export interface IUpdateForegroundServiceNotificationOptions {
+  title: string;
+  /** Omit to remove the existing body. Icon and stop action remain unchanged. */
+  body?: string;
+}
+
+export interface IForegroundServiceError {
+  code: string;
+  message: string;
+}
+
+export interface IForegroundServiceState {
+  status: ForegroundServiceStatus;
+  taskKey: string | null;
+  types: ForegroundServiceType[];
+  notificationId: number | null;
+  startedAt: number | null;
+  stopReason: ForegroundServiceStopReason | null;
+  error: IForegroundServiceError | null;
+}
+
+export type ForegroundServiceEventType =
+  | 'starting'
+  | 'started'
+  | 'notificationUpdated'
+  | 'stopping'
+  | 'stopped'
+  | 'failed';
+
+export interface IForegroundServiceEvent {
+  type: ForegroundServiceEventType;
+  state: IForegroundServiceState;
+}
+
+export type ForegroundServiceListener = (
+  event: IForegroundServiceEvent,
+) => void;

--- a/packages/foreground-service/tsconfig.json
+++ b/packages/foreground-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "../../core/engine" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ catalogs:
     prettier-plugin-svelte:
       specifier: ^4.1.1
       version: 4.1.1
+    react-native:
+      specifier: 0.86.0
+      version: 0.86.0
     react-native-bootsplash:
       specifier: 7.3.2
       version: 7.3.2
@@ -1024,6 +1027,18 @@ importers:
         version: 6.0.3
 
   packages/expo-modules-link: {}
+
+  packages/foreground-service:
+    devDependencies:
+      '@symbiote-native/engine':
+        specifier: workspace:*
+        version: link:../../core/engine
+      react-native:
+        specifier: 'catalog:'
+        version: 0.86.0(@babel/core@7.29.7)(@react-native-community/cli@20.1.0(typescript@6.0.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
 
   packages/haptics:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "adapters/svelte" },
     { "path": "adapters/solid" },
     { "path": "packages/application" },
+    { "path": "packages/foreground-service" },
     { "path": "packages/slider" },
     { "path": "packages/splash-screen" },
     { "path": "packages/navigation" },


### PR DESCRIPTION
## Summary

- add `@symbiote-native/foreground-service` with one framework-independent API for all adapters
- support Android `microphone` and `mediaPlayback` foreground-service types
- provide persistent notification creation/updates, optional native stop action, state queries, and lifecycle events
- deliver work through a registered cancellable Headless JS task, including cold React runtime startup
- harden ownership, cancellation, redelivery, stale-intent, timeout, and competing-start paths
- ship Android manifest/autolinking metadata, package contracts, Kotlin tests, README, and docs-site documentation

## Stack

Depends on #64. Until #64 merges, this PR intentionally contains its prerequisite commit; afterward the diff against `develop` will collapse to the foreground-service commit only.

## Permission boundary

The package contributes `FOREGROUND_SERVICE`, the microphone/media-playback foreground-service permissions, and `WAKE_LOCK`. Applications remain responsible for declaring/requesting `RECORD_AUDIO` and, where desired, `POST_NOTIFICATIONS`.

This is lifecycle infrastructure—not a recorder, player, Media3 session, boot service, or unlimited background-job escape hatch.

## Validation

- full Vitest and Node suites
- TypeScript, prepublish build, dependency, lint, and formatting gates
- Kotlin unit tests, compilation, Android lint, and AAR assembly
- exact packed-tarball install, React Native autolinking, and merged-manifest checks

## Remaining device gate

Actual Android OS behavior still needs a device/emulator canary for cold-process delivery, foreground-to-background continuation, notification-action stopping, permission/background-start rejection, and service redelivery. Issue #58 should remain open until that is verified.

Refs #58